### PR TITLE
feat: Add full compatibility for Pi's auth.json

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -6872,7 +6872,7 @@ fn extract_tool_calls(content: &[ContentBlock]) -> Vec<ToolCall> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::auth::AuthCredential;
+    use crate::auth::{ApiKeyValue, AuthCredential};
     use crate::provider::{InputType, Model, ModelCost};
     use async_trait::async_trait;
     use futures::Stream;
@@ -7394,13 +7394,13 @@ mod tests {
         auth.set(
             "anthropic",
             AuthCredential::ApiKey {
-                key: "anthropic-key".to_string(),
+                key: ApiKeyValue::Raw("anthropic-key".to_string()),
             },
         );
         auth.set(
             "openai",
             AuthCredential::ApiKey {
-                key: "openai-key".to_string(),
+                key: ApiKeyValue::Raw("openai-key".to_string()),
             },
         );
 
@@ -7429,7 +7429,7 @@ mod tests {
         auth.set(
             "anthropic",
             AuthCredential::ApiKey {
-                key: "anthropic-key".to_string(),
+                key: ApiKeyValue::Raw("anthropic-key".to_string()),
             },
         );
 
@@ -7720,13 +7720,13 @@ mod tests {
             auth.set(
                 "anthropic",
                 AuthCredential::ApiKey {
-                    key: "anthropic-key".to_string(),
+                    key: ApiKeyValue::Raw("anthropic-key".to_string()),
                 },
             );
             auth.set(
                 "openai",
                 AuthCredential::ApiKey {
-                    key: "openai-key".to_string(),
+                    key: ApiKeyValue::Raw("openai-key".to_string()),
                 },
             );
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -93,12 +93,63 @@ const KIMI_SHARE_DIR_ENV_KEY: &str = "KIMI_SHARE_DIR";
 const KIMI_CODE_DEVICE_AUTHORIZATION_PATH: &str = "/api/oauth/device_authorization";
 const KIMI_CODE_TOKEN_PATH: &str = "/api/oauth/token";
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(from = "String", into = "String")]
+pub enum ApiKeyValue {
+    EnvVar(String),
+    Command(String),
+    Raw(String),
+}
+
+impl From<String> for ApiKeyValue {
+    fn from(s: String) -> Self {
+        if s.starts_with("!") {
+            Self::Command(s[1..].to_string())
+        } else if std::env::var_os(&s).is_some() {
+            Self::EnvVar(s)
+        } else {
+            Self::Raw(s)
+        }
+    }
+}
+
+impl From<ApiKeyValue> for String {
+    fn from(val: ApiKeyValue) -> Self {
+        match val {
+            ApiKeyValue::Raw(s) => s,
+            ApiKeyValue::EnvVar(s) => s,
+            ApiKeyValue::Command(s) => format!("!{s}"),
+        }
+    }
+}
+
+impl From<&String> for ApiKeyValue {
+    fn from(s: &String) -> Self {
+        Self::from(s.clone())
+    }
+}
+
+impl PartialEq<str> for ApiKeyValue {
+    fn eq(&self, other: &str) -> bool {
+        match self {
+            Self::Raw(s) => s == other,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<&str> for ApiKeyValue {
+    fn eq(&self, other: &&str) -> bool {
+        self.eq(*other)
+    }
+}
+
 /// Credentials stored in auth.json.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AuthCredential {
     ApiKey {
-        key: String,
+        key: ApiKeyValue,
     },
     OAuth {
         access_token: String,
@@ -797,7 +848,20 @@ impl AuthStorage {
 
 fn api_key_from_credential(credential: &AuthCredential) -> Option<String> {
     match credential {
-        AuthCredential::ApiKey { key } => Some(key.clone()),
+        AuthCredential::ApiKey { key } => match key {
+            ApiKeyValue::Raw(s) => Some(s.clone()),
+            ApiKeyValue::EnvVar(s) => std::env::var(s).ok(),
+            ApiKeyValue::Command(s) => std::process::Command::new("/bin/sh")
+                .arg("-c")
+                .arg(s)
+                .output()
+                .and_then(|o| {
+                    Ok(String::from(
+                        std::str::from_utf8(o.stdout.as_slice()).unwrap().trim(),
+                    ))
+                })
+                .ok(),
+        },
         AuthCredential::OAuth {
             access_token,
             expires,
@@ -1280,7 +1344,12 @@ where
         Some(AuthCredential::ApiKey { key }) => {
             // Legacy: treat stored API key as bearer token for Bedrock
             Some(AwsResolvedCredentials::Bearer {
-                token: key.clone(),
+                token: match key {
+                    ApiKeyValue::Raw(s) => s.clone(),
+                    // Legacy: these should never be encountered :-(
+                    ApiKeyValue::EnvVar(s) => s.clone(),
+                    ApiKeyValue::Command(s) => s.clone(),
+                },
                 region,
             })
         }
@@ -1713,11 +1782,14 @@ pub fn start_oauth_callback_server_random_port() -> Result<(OAuthCallbackServer,
         ))
     })?;
 
-    let port = listener.local_addr().map_err(|e| {
-        Error::auth(format!(
-            "Failed to get local address of OAuth callback listener: {e}"
-        ))
-    })?.port();
+    let port = listener
+        .local_addr()
+        .map_err(|e| {
+            Error::auth(format!(
+                "Failed to get local address of OAuth callback listener: {e}"
+            ))
+        })?
+        .port();
 
     let redirect_uri = format!("http://localhost:{port}/callback");
 
@@ -3738,6 +3810,55 @@ mod tests {
     use std::net::TcpListener;
     use std::time::Duration;
 
+    #[test]
+    fn test_api_key_value_from_string() {
+        // Raw
+        let val: ApiKeyValue = (&"raw-key".to_string()).into();
+        assert_eq!(val, ApiKeyValue::Raw("raw-key".to_string()));
+
+        // EnvVar (using HOME which is always set)
+        let val: ApiKeyValue = (&"HOME".to_string()).into();
+        assert_eq!(val, ApiKeyValue::EnvVar("HOME".to_string()));
+
+        // Command
+        let val: ApiKeyValue = (&"!echo hello".to_string()).into();
+        assert_eq!(val, ApiKeyValue::Command("echo hello".to_string()));
+    }
+
+    #[test]
+    fn test_api_key_value_partial_eq() {
+        let val = ApiKeyValue::Raw("test".to_string());
+        assert_eq!(val, "test");
+
+        let val = ApiKeyValue::EnvVar("HOME".to_string());
+        assert!(val != "HOME");
+
+        let val = ApiKeyValue::Command("echo hi".to_string());
+        assert!(val != "echo hi");
+    }
+
+    #[test]
+    fn test_api_key_from_credential_resolution() {
+        // Raw
+        let cred = AuthCredential::ApiKey {
+            key: ApiKeyValue::Raw("raw".into()),
+        };
+        assert_eq!(api_key_from_credential(&cred), Some("raw".into()));
+
+        // EnvVar (using HOME)
+        let home_val = std::env::var("HOME").unwrap();
+        let cred = AuthCredential::ApiKey {
+            key: ApiKeyValue::EnvVar("HOME".into()),
+        };
+        assert_eq!(api_key_from_credential(&cred), Some(home_val));
+
+        // Command (this confirms the bug fix)
+        let cred = AuthCredential::ApiKey {
+            key: ApiKeyValue::Command("echo resolved".into()),
+        };
+        assert_eq!(api_key_from_credential(&cred), Some("resolved".into()));
+    }
+
     fn next_token() -> String {
         static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
@@ -3912,7 +4033,7 @@ mod tests {
             auth.set(
                 "openai",
                 AuthCredential::ApiKey {
-                    key: "stored-openai-key".to_string(),
+                    key: ApiKeyValue::Raw("stored-openai-key".to_string()),
                 },
             );
             auth.save().expect("save");
@@ -3970,7 +4091,7 @@ mod tests {
         auth.set(
             "openai",
             AuthCredential::ApiKey {
-                key: "openai-key-test".to_string(),
+                key: ApiKeyValue::Raw("openai-key-test".to_string()),
             },
         );
         auth.save().expect("save auth");
@@ -4045,7 +4166,7 @@ mod tests {
         auth.set(
             "google",
             AuthCredential::ApiKey {
-                key: "google-key-test".to_string(),
+                key: ApiKeyValue::Raw("google-key-test".to_string()),
             },
         );
         auth.save().expect("save auth");
@@ -4088,7 +4209,7 @@ mod tests {
         auth.set(
             "openai",
             AuthCredential::ApiKey {
-                key: "stored-openai-key".to_string(),
+                key: ApiKeyValue::Raw("stored-openai-key".to_string()),
             },
         );
 
@@ -4873,7 +4994,7 @@ mod tests {
         auth.set(
             "google",
             AuthCredential::ApiKey {
-                key: "google-key".to_string(),
+                key: ApiKeyValue::Raw("google-key".to_string()),
             },
         );
 
@@ -4912,7 +5033,7 @@ mod tests {
         auth.set(
             "gemini",
             AuthCredential::ApiKey {
-                key: "legacy-gemini-key".to_string(),
+                key: ApiKeyValue::Raw("legacy-gemini-key".to_string()),
             },
         );
 
@@ -4931,7 +5052,7 @@ mod tests {
         auth.set(
             "Google",
             AuthCredential::ApiKey {
-                key: "mixed-case-key".to_string(),
+                key: ApiKeyValue::Raw("mixed-case-key".to_string()),
             },
         );
 
@@ -4950,7 +5071,7 @@ mod tests {
         auth.set(
             "gemini",
             AuthCredential::ApiKey {
-                key: "legacy-gemini-key".to_string(),
+                key: ApiKeyValue::Raw("legacy-gemini-key".to_string()),
             },
         );
 
@@ -4968,13 +5089,13 @@ mod tests {
         auth.set(
             "google",
             AuthCredential::ApiKey {
-                key: "google-key".to_string(),
+                key: ApiKeyValue::Raw("google-key".to_string()),
             },
         );
         auth.set(
             "gemini",
             AuthCredential::ApiKey {
-                key: "gemini-key".to_string(),
+                key: ApiKeyValue::Raw("gemini-key".to_string()),
             },
         );
 
@@ -4994,7 +5115,7 @@ mod tests {
         auth.set(
             "ext-provider",
             AuthCredential::ApiKey {
-                key: "key-123".to_string(),
+                key: ApiKeyValue::Raw("key-123".to_string()),
             },
         );
 
@@ -5106,7 +5227,7 @@ mod tests {
         auth.set(
             "anthropic",
             AuthCredential::ApiKey {
-                key: "stored-key".to_string(),
+                key: ApiKeyValue::Raw("stored-key".to_string()),
             },
         );
 
@@ -5127,7 +5248,7 @@ mod tests {
         auth.set(
             "openai",
             AuthCredential::ApiKey {
-                key: "stored-key".to_string(),
+                key: ApiKeyValue::Raw("stored-key".to_string()),
             },
         );
 
@@ -5151,7 +5272,7 @@ mod tests {
         auth.set(
             "groq",
             AuthCredential::ApiKey {
-                key: "stored-groq-key".to_string(),
+                key: ApiKeyValue::Raw("stored-groq-key".to_string()),
             },
         );
 
@@ -5171,7 +5292,7 @@ mod tests {
         auth.set(
             "openrouter",
             AuthCredential::ApiKey {
-                key: "stored-openrouter-key".to_string(),
+                key: ApiKeyValue::Raw("stored-openrouter-key".to_string()),
             },
         );
 
@@ -5193,7 +5314,7 @@ mod tests {
         auth.set(
             "openai",
             AuthCredential::ApiKey {
-                key: "stored-key".to_string(),
+                key: ApiKeyValue::Raw("stored-key".to_string()),
             },
         );
 
@@ -5218,7 +5339,7 @@ mod tests {
         auth.set(
             "openai",
             AuthCredential::ApiKey {
-                key: "stored-key".to_string(),
+                key: ApiKeyValue::Raw("stored-key".to_string()),
             },
         );
 
@@ -5287,7 +5408,7 @@ mod tests {
         auth.set(
             "google",
             AuthCredential::ApiKey {
-                key: "stored-google-key".to_string(),
+                key: ApiKeyValue::Raw("stored-google-key".to_string()),
             },
         );
 
@@ -5311,7 +5432,7 @@ mod tests {
         auth.set(
             "google",
             AuthCredential::ApiKey {
-                key: "stored-google-key".to_string(),
+                key: ApiKeyValue::Raw("stored-google-key".to_string()),
             },
         );
 
@@ -5330,7 +5451,7 @@ mod tests {
         auth.set(
             "gemini",
             AuthCredential::ApiKey {
-                key: "legacy-gemini-key".to_string(),
+                key: ApiKeyValue::Raw("legacy-gemini-key".to_string()),
             },
         );
 
@@ -5349,7 +5470,7 @@ mod tests {
         auth.set(
             "alibaba",
             AuthCredential::ApiKey {
-                key: "stored-dashscope-key".to_string(),
+                key: ApiKeyValue::Raw("stored-dashscope-key".to_string()),
             },
         );
 
@@ -5373,7 +5494,7 @@ mod tests {
         auth.set(
             "moonshotai",
             AuthCredential::ApiKey {
-                key: "stored-moonshot-key".to_string(),
+                key: ApiKeyValue::Raw("stored-moonshot-key".to_string()),
             },
         );
 
@@ -5418,7 +5539,7 @@ mod tests {
         auth.set(
             "openai",
             AuthCredential::ApiKey {
-                key: "sk-openai-test".to_string(),
+                key: ApiKeyValue::Raw("sk-openai-test".to_string()),
             },
         );
 
@@ -5437,13 +5558,13 @@ mod tests {
         auth.set(
             "google",
             AuthCredential::ApiKey {
-                key: "google-key-old".to_string(),
+                key: ApiKeyValue::Raw("google-key-old".to_string()),
             },
         );
         auth.set(
             "google",
             AuthCredential::ApiKey {
-                key: "google-key-new".to_string(),
+                key: ApiKeyValue::Raw("google-key-new".to_string()),
             },
         );
         auth.save().expect("save");
@@ -5464,13 +5585,13 @@ mod tests {
         auth.set(
             "anthropic",
             AuthCredential::ApiKey {
-                key: "sk-ant".to_string(),
+                key: ApiKeyValue::Raw("sk-ant".to_string()),
             },
         );
         auth.set(
             "openai",
             AuthCredential::ApiKey {
-                key: "sk-oai".to_string(),
+                key: ApiKeyValue::Raw("sk-oai".to_string()),
             },
         );
         let far_future = chrono::Utc::now().timestamp_millis() + 3_600_000;
@@ -5506,7 +5627,7 @@ mod tests {
         auth.set(
             "anthropic",
             AuthCredential::ApiKey {
-                key: "nested-key".to_string(),
+                key: ApiKeyValue::Raw("nested-key".to_string()),
             },
         );
         auth.save().expect("save should create parents");
@@ -5531,7 +5652,7 @@ mod tests {
         auth.set(
             "anthropic",
             AuthCredential::ApiKey {
-                key: "secret".to_string(),
+                key: ApiKeyValue::Raw("secret".to_string()),
             },
         );
         auth.save().expect("save");
@@ -5553,7 +5674,7 @@ mod tests {
         original.set(
             "anthropic",
             AuthCredential::ApiKey {
-                key: "old-key".to_string(),
+                key: ApiKeyValue::Raw("old-key".to_string()),
             },
         );
         original.save().expect("save original auth");
@@ -5568,7 +5689,7 @@ mod tests {
         replacement_entries.insert(
             "anthropic".to_string(),
             AuthCredential::ApiKey {
-                key: "new-key".to_string(),
+                key: ApiKeyValue::Raw("new-key".to_string()),
             },
         );
         let replacement_data = serde_json::to_string_pretty(&AuthFileRef {
@@ -5939,7 +6060,7 @@ mod tests {
         auth.set(
             "anthropic",
             AuthCredential::ApiKey {
-                key: "first-key".to_string(),
+                key: ApiKeyValue::Raw("first-key".to_string()),
             },
         );
         assert_eq!(auth.api_key("anthropic").as_deref(), Some("first-key"));
@@ -5947,7 +6068,7 @@ mod tests {
         auth.set(
             "anthropic",
             AuthCredential::ApiKey {
-                key: "second-key".to_string(),
+                key: ApiKeyValue::Raw("second-key".to_string()),
             },
         );
         assert_eq!(auth.api_key("anthropic").as_deref(), Some("second-key"));
@@ -5968,7 +6089,7 @@ mod tests {
             auth.set(
                 "anthropic",
                 AuthCredential::ApiKey {
-                    key: "old-key".to_string(),
+                    key: ApiKeyValue::Raw("old-key".to_string()),
                 },
             );
             auth.save().expect("save");
@@ -5980,7 +6101,7 @@ mod tests {
             auth.set(
                 "anthropic",
                 AuthCredential::ApiKey {
-                    key: "new-key".to_string(),
+                    key: ApiKeyValue::Raw("new-key".to_string()),
                 },
             );
             auth.save().expect("save");
@@ -6005,7 +6126,7 @@ mod tests {
         auth.set(
             "anthropic",
             AuthCredential::ApiKey {
-                key: "test-key".to_string(),
+                key: ApiKeyValue::Raw("test-key".to_string()),
             },
         );
         auth.save().expect("save");
@@ -7712,7 +7833,7 @@ mod tests {
         auth.entries.insert(
             "anthropic".to_string(),
             AuthCredential::ApiKey {
-                key: "sk-test".to_string(),
+                key: ApiKeyValue::Raw("sk-test".to_string()),
             },
         );
 

--- a/src/interactive/commands.rs
+++ b/src/interactive/commands.rs
@@ -2,6 +2,7 @@ use super::*;
 
 use crate::models::{ModelEntry, model_requires_configured_credential, normalize_api_key_opt};
 use crate::provider_metadata::{provider_ids_match, split_provider_model_spec};
+use crate::auth::ApiKeyValue;
 
 #[cfg(feature = "clipboard")]
 use arboard::Clipboard as ArboardClipboard;
@@ -897,7 +898,7 @@ impl PiApp {
 
             let credential = match kind {
                 PendingLoginKind::ApiKey => normalize_api_key_input(&code_input)
-                    .map(|key| crate::auth::AuthCredential::ApiKey { key })
+                    .map(|key| crate::auth::AuthCredential::ApiKey { key: ApiKeyValue::Raw(key) })
                     .map_err(crate::error::Error::auth),
                 PendingLoginKind::OAuth => {
                     if provider == "anthropic" {
@@ -2421,7 +2422,7 @@ result in account suspension/ban. Prefer using an Anthropic API key (ANTHROPIC_A
 #[cfg(test)]
 mod tests {
     use super::{parse_bash_command, parse_extension_command, should_show_startup_oauth_hint};
-    use crate::auth::{AuthCredential, AuthStorage};
+    use crate::auth::{ApiKeyValue, AuthCredential, AuthStorage};
     use crate::models::ModelEntry;
     use crate::provider::{InputType, Model, ModelCost};
     use std::collections::{HashMap, HashSet};
@@ -2590,7 +2591,7 @@ mod tests {
         auth.set(
             "anthropic",
             AuthCredential::ApiKey {
-                key: "test-key".to_string(),
+                key: ApiKeyValue::Raw("test-key".to_string()),
             },
         );
         assert!(!should_show_startup_oauth_hint(&auth));
@@ -2602,7 +2603,7 @@ mod tests {
         auth.set(
             "openai",
             AuthCredential::ApiKey {
-                key: "test-openai-key".to_string(),
+                key: ApiKeyValue::Raw("test-openai-key".to_string()),
             },
         );
         assert!(!should_show_startup_oauth_hint(&auth));
@@ -2694,7 +2695,7 @@ mod tests {
             &mut auth,
             "gemini",
             AuthCredential::ApiKey {
-                key: "new-google-token".to_string(),
+                key: ApiKeyValue::Raw("new-google-token".to_string()),
             },
         );
 
@@ -2711,7 +2712,7 @@ mod tests {
         auth.set(
             "openai",
             AuthCredential::ApiKey {
-                key: "stored-auth-token".to_string(),
+                key: ApiKeyValue::Raw("stored-auth-token".to_string()),
             },
         );
 
@@ -2742,13 +2743,13 @@ mod tests {
         auth.set(
             "google",
             AuthCredential::ApiKey {
-                key: "google-key".to_string(),
+                key: ApiKeyValue::Raw("google-key".to_string()),
             },
         );
         auth.set(
             "gemini",
             AuthCredential::ApiKey {
-                key: "gemini-key".to_string(),
+                key: ApiKeyValue::Raw("gemini-key".to_string()),
             },
         );
 

--- a/src/interactive/tests.rs
+++ b/src/interactive/tests.rs
@@ -1,6 +1,7 @@
 use super::share::{parse_gist_url_and_id, parse_share_is_public, share_gist_description};
 use super::*;
 use crate::agent::AgentConfig;
+use crate::auth::ApiKeyValue;
 use crate::extensions::{ExtensionManager, PROTOCOL_VERSION, RegisterPayload};
 use crate::model::StreamEvent;
 use crate::provider::{Context, Provider, StreamOptions};
@@ -1492,7 +1493,7 @@ fn format_login_provider_listing_includes_builtin_and_extension_status() {
     auth.set(
         "google",
         crate::auth::AuthCredential::ApiKey {
-            key: "google-api-key".to_string(),
+            key: ApiKeyValue::Raw("google-api-key".to_string()),
         },
     );
     auth.set(
@@ -1539,7 +1540,7 @@ fn save_provider_credential_persists_google_under_canonical_key() {
         &mut auth,
         "gemini",
         crate::auth::AuthCredential::ApiKey {
-            key: "gemini-test-key".to_string(),
+            key: ApiKeyValue::Raw("gemini-test-key".to_string()),
         },
     );
     auth.save().expect("save credential");
@@ -1557,13 +1558,13 @@ fn remove_provider_credentials_clears_google_and_gemini_aliases() {
     auth.set(
         "google",
         crate::auth::AuthCredential::ApiKey {
-            key: "google-key".to_string(),
+            key: ApiKeyValue::Raw("google-key".to_string()),
         },
     );
     auth.set(
         "gemini",
         crate::auth::AuthCredential::ApiKey {
-            key: "legacy-gemini-key".to_string(),
+            key: ApiKeyValue::Raw("legacy-gemini-key".to_string()),
         },
     );
     auth.save().expect("seed auth");

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use pi::agent::{
     AbortHandle, Agent, AgentConfig, AgentEvent, AgentSession, PreWarmedExtensionRuntime,
 };
 use pi::app::StartupError;
-use pi::auth::{AuthCredential, AuthStorage};
+use pi::auth::{ApiKeyValue, AuthCredential, AuthStorage};
 use pi::cli;
 use pi::compaction::ResolvedCompactionSettings;
 use pi::config::Config;
@@ -3615,7 +3615,7 @@ async fn run_first_time_setup(
             }
 
             AuthCredential::ApiKey {
-                key: key.to_string(),
+                key: ApiKeyValue::Raw(key.to_string()),
             }
         }
         SetupCredentialKind::OAuthPkce => {

--- a/src/models.rs
+++ b/src/models.rs
@@ -1745,7 +1745,7 @@ pub(crate) fn ad_hoc_model_entry(provider: &str, model_id: &str) -> Option<Model
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::auth::{AuthCredential, AuthStorage};
+    use crate::auth::{ApiKeyValue, AuthCredential, AuthStorage};
     use tempfile::tempdir;
 
     fn test_auth_storage() -> (tempfile::TempDir, AuthStorage) {
@@ -1755,31 +1755,31 @@ mod tests {
         auth.set(
             "anthropic",
             AuthCredential::ApiKey {
-                key: "anthropic-auth-key".to_string(),
+                key: ApiKeyValue::Raw("anthropic-auth-key".to_string()),
             },
         );
         auth.set(
             "openai",
             AuthCredential::ApiKey {
-                key: "openai-auth-key".to_string(),
+                key: ApiKeyValue::Raw("openai-auth-key".to_string()),
             },
         );
         auth.set(
             "google",
             AuthCredential::ApiKey {
-                key: "google-auth-key".to_string(),
+                key: ApiKeyValue::Raw("google-auth-key".to_string()),
             },
         );
         auth.set(
             "openrouter",
             AuthCredential::ApiKey {
-                key: "openrouter-auth-key".to_string(),
+                key: ApiKeyValue::Raw("openrouter-auth-key".to_string()),
             },
         );
         auth.set(
             "acme",
             AuthCredential::ApiKey {
-                key: "acme-auth-key".to_string(),
+                key: ApiKeyValue::Raw("acme-auth-key".to_string()),
             },
         );
         (dir, auth)
@@ -2362,7 +2362,7 @@ mod tests {
         auth.set(
             "moonshotai",
             AuthCredential::ApiKey {
-                key: "moonshot-auth-key".to_string(),
+                key: ApiKeyValue::Raw("moonshot-auth-key".to_string()),
             },
         );
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -4728,7 +4728,7 @@ async fn cycle_model_for_rpc(
 mod tests {
     use super::*;
     use crate::agent::{Agent, AgentConfig};
-    use crate::auth::AuthCredential;
+    use crate::auth::{ApiKeyValue, AuthCredential};
     use crate::model::{
         AssistantMessage, ContentBlock, ImageContent, StopReason, TextContent, ThinkingLevel,
         Usage, UserContent, UserMessage,
@@ -5228,7 +5228,7 @@ export default function init(pi) {
         auth.set(
             "openai".to_string(),
             AuthCredential::ApiKey {
-                key: "stored-auth-key".to_string(),
+                key: ApiKeyValue::Raw("stored-auth-key".to_string()),
             },
         );
 
@@ -5253,7 +5253,7 @@ export default function init(pi) {
         auth.set(
             "openai".to_string(),
             AuthCredential::ApiKey {
-                key: "stored-auth-key".to_string(),
+                key: ApiKeyValue::Raw("stored-auth-key".to_string()),
             },
         );
 

--- a/tests/auth_oauth_refresh_vcr.rs
+++ b/tests/auth_oauth_refresh_vcr.rs
@@ -354,7 +354,7 @@ fn auth_oauth_refresh_api_key_credentials_skip_refresh_vcr() {
         auth.set(
             "google",
             AuthCredential::ApiKey {
-                key: "google-api-key-test".to_string(),
+                key: pi::auth::ApiKeyValue::Raw("google-api-key-test".to_string()),
             },
         );
         auth.save().expect("save auth.json");

--- a/tests/extensions_auth_error_coverage.rs
+++ b/tests/extensions_auth_error_coverage.rs
@@ -47,7 +47,7 @@ fn auth_storage_save_reload_api_key() {
     storage.set(
         "anthropic",
         AuthCredential::ApiKey {
-            key: "sk-test-key-123".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("sk-test-key-123".to_string()),
         },
     );
     storage.save().expect("save should succeed");
@@ -234,7 +234,7 @@ fn resolve_api_key_override_wins() {
     storage.set(
         "provider",
         AuthCredential::ApiKey {
-            key: "stored-key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("stored-key".to_string()),
         },
     );
 
@@ -250,7 +250,7 @@ fn resolve_api_key_stored_used() {
     storage.set(
         "provider",
         AuthCredential::ApiKey {
-            key: "stored-key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("stored-key".to_string()),
         },
     );
 
@@ -391,7 +391,7 @@ fn prune_stale_preserves_non_oauth() {
     storage.set(
         "api-key-provider",
         AuthCredential::ApiKey {
-            key: "key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("key".to_string()),
         },
     );
     storage.set(
@@ -426,7 +426,7 @@ fn auth_storage_remove() {
     storage.set(
         "provider",
         AuthCredential::ApiKey {
-            key: "key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("key".to_string()),
         },
     );
     assert!(
@@ -506,7 +506,7 @@ fn resolve_aws_legacy_api_key_as_bearer() {
     storage.set(
         "amazon-bedrock",
         AuthCredential::ApiKey {
-            key: "legacy-bedrock-key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("legacy-bedrock-key".to_string()),
         },
     );
 
@@ -718,7 +718,7 @@ fn auth_credential_serde_round_trip() {
         (
             "api_key",
             AuthCredential::ApiKey {
-                key: "test-key".to_string(),
+                key: pi::auth::ApiKeyValue::Raw("test-key".to_string()),
             },
         ),
         (
@@ -860,13 +860,13 @@ fn auth_storage_multiple_providers() {
     storage.set(
         "anthropic",
         AuthCredential::ApiKey {
-            key: "anthropic-key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("anthropic-key".to_string()),
         },
     );
     storage.set(
         "openai",
         AuthCredential::ApiKey {
-            key: "openai-key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("openai-key".to_string()),
         },
     );
     storage.set(
@@ -899,7 +899,7 @@ fn auth_storage_overwrite_provider() {
     storage.set(
         "provider",
         AuthCredential::ApiKey {
-            key: "old-key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("old-key".to_string()),
         },
     );
     assert_eq!(storage.api_key("provider").as_deref(), Some("old-key"));
@@ -907,7 +907,7 @@ fn auth_storage_overwrite_provider() {
     storage.set(
         "provider",
         AuthCredential::ApiKey {
-            key: "new-key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("new-key".to_string()),
         },
     );
     assert_eq!(storage.api_key("provider").as_deref(), Some("new-key"));

--- a/tests/main_cli_selection.rs
+++ b/tests/main_cli_selection.rs
@@ -28,7 +28,7 @@ fn make_registry(harness: &TestHarness, creds: &[(&str, &str)]) -> ModelRegistry
         auth.set(
             (*provider).to_string(),
             AuthCredential::ApiKey {
-                key: (*key).to_string(),
+                key: pi::auth::ApiKeyValue::Raw((*key).to_string()),
             },
         );
     }
@@ -632,7 +632,7 @@ fn resolve_api_key_precedence_and_error_paths() {
     auth.set(
         "custom".to_string(),
         AuthCredential::ApiKey {
-            key: "auth-key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("auth-key".to_string()),
         },
     );
 

--- a/tests/provider_factory.rs
+++ b/tests/provider_factory.rs
@@ -679,7 +679,7 @@ fn schema_metadata_drives_alias_provider_selection_end_to_end() {
     auth.set(
         "moonshotai",
         AuthCredential::ApiKey {
-            key: "moonshot-schema-key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("moonshot-schema-key".to_string()),
         },
     );
     auth.save().expect("save auth storage");
@@ -739,7 +739,7 @@ fn schema_metadata_drives_native_anthropic_selection_end_to_end() {
     auth.set(
         "anthropic",
         AuthCredential::ApiKey {
-            key: "anthropic-schema-key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("anthropic-schema-key".to_string()),
         },
     );
     auth.save().expect("save auth storage");
@@ -2162,7 +2162,7 @@ fn fireworks_ai_alias_migration_matches_fireworks_canonical_defaults() {
     auth.set(
         "fireworks",
         AuthCredential::ApiKey {
-            key: "fireworks-schema-key".to_string(),
+            key: pi::auth::ApiKeyValue::Raw("fireworks-schema-key".to_string()),
         },
     );
     auth.save().expect("save auth storage");


### PR DESCRIPTION
## Summary
- What changed: In addition to use of a raw key, as already supported, add the ability to use an environment variable or the output of a shell command.

To maintain type safety, this refactors the parsing of `auth.json` to add an `ApiKeyValue` type, to handle the different ways to specify an API key.

- Why: a) Better security story, supporting environment variables and command outputs for secrets; b) better compatibility with Typescript Pi
- Risk level (low/medium/high): medium

## Definition of Done Evidence
- [ ] Unit evidence linked
- [ ] E2E evidence linked
- [ ] Extension evidence linked
- [ ] Failing paths include artifact links and repro commands

### Unit Evidence
- Primary run link(s):
- Notes:

### E2E Evidence
- Primary run link(s):
- Notes:

### Extension Evidence
- Primary run link(s):
- Notes:

## Reproduction Commands
```bash
cargo test --all-targets
cargo test --all-targets --features ext-conformance
./scripts/e2e/run_all.sh --profile ci
```

## Migration Guidance (Existing Feature Branches)
- If this branch was created before the DoD gate rollout, replace the PR body with this template before requesting merge.
- For historical failing runs, include direct artifact links plus the exact rerun command used to validate the fix.
