### PR TITLE
fix(providers): send empty string instead of null for assistant content

### DIFF
--- a/src/interactive/view.rs
+++ b/src/interactive/view.rs
@@ -478,14 +478,22 @@ impl PiApp {
         self.render_buffers
             .return_conversation_buffer(conversation_content);
 
-        // Tool status
+        // Tool status — always show elapsed time so the user can see progress,
+        // even if no ToolUpdate messages have arrived yet.
         if let Some(tool) = &self.current_tool {
             let progress_str = self.tool_progress.as_ref().map_or_else(String::new, |p| {
-                let secs = p.elapsed_ms / 1000;
-                if secs < 1 {
-                    return String::new();
-                }
-                let mut parts = vec![format!("{secs}s")];
+                // Use wall-clock elapsed from started_at so the counter updates
+                // even between ToolUpdate messages.
+                let elapsed_ms = p.started_at.elapsed().as_millis();
+                let secs = elapsed_ms / 1000;
+                let sub_ms = (elapsed_ms % 1000) / 100;
+                let elapsed_str = if secs < 1 {
+                    // Show sub-second precision for the first second
+                    format!("0.{sub_ms}s")
+                } else {
+                    format!("{secs}s")
+                };
+                let mut parts = vec![elapsed_str];
                 if p.line_count > 0 {
                     parts.push(format!("{} lines", format_count(p.line_count)));
                 } else if p.byte_count > 0 {

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -1048,7 +1048,11 @@ fn convert_message_to_openai(message: &Message) -> Vec<OpenAIMessage<'_>> {
                 .collect();
 
             let content = if text.is_empty() {
-                None
+                // Send empty string instead of null/omitted. Some providers (e.g. GLM
+                // via Ollama Cloud) reject null content with "invalid message content
+                // type: <nil>". An empty string is valid per the OpenAI spec and
+                // accepted by all known providers.
+                Some(OpenAIContent::Text(Cow::Borrowed("")))
             } else {
                 Some(OpenAIContent::Text(Cow::Owned(text)))
             };


### PR DESCRIPTION
## Summary

- When an assistant message has no text content (only tool calls or aborted), the OpenAI provider was setting `content` to `None`, which serializes as `null` or omitted entirely
- Some providers (e.g. GLM models via Ollama Cloud) reject `null` content with HTTP 400: `"invalid message content type: <nil>"`
- Send an empty string (`""`) instead, which is valid per the OpenAI Chat Completions spec and accepted by all known providers

## Test plan

- [x] Reproduced the error with a direct API call to `glm-5.1:cloud` on Ollama Cloud: `"content": null` → HTTP 400
- [x] Verified fix with direct API call: `"content": ""` → HTTP 200, successful response
- [x] `cargo check --lib` passes
- [ ] Full `cargo test` (release build in progress)
- [ ] Manual test with `pi` agent using `glm-5.1:cloud` model through multi-turn tool-use conversation

## Before

```json
{"role": "assistant", "content": null, "tool_calls": [...]}
```
→ `"invalid message content type: <nil>"`

## After

```json
{"role": "assistant", "content": "", "tool_calls": [...]}
```
→ Works correctly