### PR TITLE
sdk: add SessionOptions::tool_factory for custom ToolRegistry injection

### DIFF
--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -297,6 +297,15 @@ pub struct SessionOptions {
     pub include_cwd_in_prompt: bool,
     pub max_tool_iterations: usize,
 
+    /// Optional factory for producing the session's [`ToolRegistry`].
+    ///
+    /// When `None`, `create_agent_session` builds the default built-in
+    /// tool set from [`SessionOptions::enabled_tools`] (the existing
+    /// behaviour). Setting it lets a consumer register custom tools,
+    /// wrap the built-ins (e.g. with approval gates), or replace the
+    /// set entirely — see [`ToolFactory`] and [`default_tool_registry`].
+    pub tool_factory: Option<Arc<dyn ToolFactory>>,
+
     /// Session-level event listener invoked for every [`AgentEvent`].
     ///
     /// Unlike the per-prompt callback passed to [`AgentSessionHandle::prompt`],
@@ -332,12 +341,37 @@ impl Default for SessionOptions {
             repair_policy: None,
             include_cwd_in_prompt: true,
             max_tool_iterations: 50,
+            tool_factory: None,
             on_event: None,
             on_tool_start: None,
             on_tool_end: None,
             on_stream_event: None,
         }
     }
+}
+
+/// Factory for producing the session's [`ToolRegistry`].
+///
+/// Implement this on a `Send + Sync` type and attach it to
+/// [`SessionOptions::tool_factory`] to register custom tools or wrap the
+/// built-in ones. See [`default_tool_registry`] for the current default.
+pub trait ToolFactory: Send + Sync {
+    /// Build the registry.
+    ///
+    /// - `enabled` is the resolved tool-name allowlist derived from
+    ///   [`SessionOptions::enabled_tools`] (and CLI defaults).
+    /// - `cwd` is the working directory the session was created in.
+    /// - `config` is pi's loaded [`Config`] — passed through so custom
+    ///   tools can consult settings like `block_images`.
+    fn build(&self, enabled: &[&str], cwd: &Path, config: &Config) -> ToolRegistry;
+}
+
+/// The default factory behaviour: delegates to [`ToolRegistry::new`].
+///
+/// Call this from your own [`ToolFactory`] impl to layer on top of the
+/// built-in tool set without re-implementing the resolution rules.
+pub fn default_tool_registry(enabled: &[&str], cwd: &Path, config: &Config) -> ToolRegistry {
+    ToolRegistry::new(enabled, cwd, Some(config))
 }
 
 /// Lightweight handle for programmatic embedding.
@@ -1652,7 +1686,10 @@ pub async fn create_agent_session(options: SessionOptions) -> Result<AgentSessio
         fail_closed_hooks: config.fail_closed_hooks(),
     };
 
-    let tools = ToolRegistry::new(&enabled_tools, &cwd, Some(&config));
+    let tools = match &options.tool_factory {
+        Some(factory) => factory.build(&enabled_tools, &cwd, &config),
+        None => ToolRegistry::new(&enabled_tools, &cwd, Some(&config)),
+    };
     let session_arc = Arc::new(asupersync::sync::Mutex::new(session));
 
     let context_window_tokens = if selection.model_entry.model.context_window == 0 {


### PR DESCRIPTION
## Summary

Adds an optional `ToolFactory` hook on `SessionOptions` so crates embedding pi via `pi::sdk::create_agent_session` can register custom tools (approval wrappers, subagent / Task tools, policy gates, restricted tool sets for a "plan mode", etc.) without bypassing the factory. No existing caller is affected — the field defaults to `None` and preserves today's behaviour bit-for-bit.

## Motivation

We're building an own-brand coding agent as a subcommand of [libertai-cli](https://github.com/Libertai/libertai-cli) that embeds pi through the stable SDK. For that to be usable, we need:

- **Tool-call approvals** (\"Allow bash? y/n / always\") — we wrap each built-in tool with an approval gate.
- **Plan mode** — a read-only mode where `bash`, `edit`, `write`, and `hashline_edit` simply aren't registered, so the model can only read + describe its plan.
- **Subagents** — a `Task` tool that spawns a nested, sandboxed `AgentSession`.

None of those were reachable through the existing SDK: `AgentSessionHandle`'s internals are private and `ToolRegistry` is built once, inside `create_agent_session`, with no way to swap the set or wrap the built-ins.

`acp.rs` already notes `\"Permission callback support is not yet implemented; tool_approval capability is advertised as false until the ACP spec stabilises the request_permission flow.\"` This PR doesn't implement permissions at the SDK level — it just unlocks the extension point so consumers can do so.

## API

```rust
pub trait ToolFactory: Send + Sync {
    fn build(&self, enabled: &[&str], cwd: &Path, config: &Config) -> ToolRegistry;
}

pub fn default_tool_registry(enabled: &[&str], cwd: &Path, config: &Config) -> ToolRegistry;

pub struct SessionOptions {
    // ...existing fields unchanged...
    pub tool_factory: Option<Arc<dyn ToolFactory>>,
}
```

`create_agent_session` branches once:

```rust
let tools = match &options.tool_factory {
    Some(factory) => factory.build(&enabled_tools, &cwd, &config),
    None => ToolRegistry::new(&enabled_tools, &cwd, Some(&config)),
};
```

The companion `default_tool_registry(...)` exposes today's construction so custom factories can layer on top (add tools) rather than having to rebuild from scratch.

## Back-compat

- New field is `Option<Arc<dyn ToolFactory>>`, defaults to `None`.
- `SessionOptions::default()` sets `tool_factory: None`.
- When `None`, `create_agent_session` runs the exact same `ToolRegistry::new(&enabled_tools, &cwd, Some(&config))` call as before.
- No public signature changed other than the new optional field.
- No semver-breaking change for existing callers — but the new field makes `SessionOptions` hold a non-`Clone` `Arc<dyn Trait>`, which is fine since `Arc` is `Clone` and the struct already derives `Clone`.

## Test plan

- [x] `cargo build` clean on the branch.
- [x] Downstream smoke: libertai-cli's `libertai code \"...\"` still streams end-to-end against a local `path = \"../pi_agent_rust\"` dep using this branch, with no custom `tool_factory` set (confirms the `None` path preserves behaviour).
- [ ] (Reviewer-side) `cargo test` across the workspace to confirm no test assumed a specific `SessionOptions` field count.

Happy to iterate on the trait name / shape — `ToolFactory::build` vs. `create_tools`, `Arc<dyn …>` vs. a boxed closure, etc. Whatever fits the rest of the SDK conventions.