### PR TITLE
fix(allocator): exclude tikv-jemallocator on FreeBSD to fix #57 SIGSEGV (double-jemalloc heap corruption)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,20 @@ extern crate self as pi;
 
 // Gap H: jemalloc allocator for allocation-heavy paths.
 // Declared in the library so all project binaries/tests share allocator behavior.
-#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
+//
+// Excluded on FreeBSD: FreeBSD's libc malloc is itself jemalloc-derived,
+// so installing tikv-jemallocator via #[global_allocator] puts a second
+// jemalloc instance into the same process. The two allocators' metadata
+// regions interfere and cause silent heap corruption that manifests at
+// the next allocator touch (often pthread_attr_init during a fresh thread
+// spawn — see pi#57 for the lldb backtrace). Use the system allocator on
+// FreeBSD; tikv-jemallocator stays in the dep graph so build behavior is
+// symmetric across targets, but is not registered as global on FreeBSD.
+#[cfg(all(
+    feature = "jemalloc",
+    not(target_env = "msvc"),
+    not(target_os = "freebsd")
+))]
 #[global_allocator]
 static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/src/perf_build.rs
+++ b/src/perf_build.rs
@@ -55,9 +55,17 @@ enum RequestedAllocator {
 }
 
 /// Returns the allocator compiled into the current binary.
+///
+/// Note: jemalloc is suppressed on FreeBSD even when the feature is on,
+/// because FreeBSD's libc malloc is itself jemalloc-derived and a second
+/// instance corrupts heap state. See the cfg in `lib.rs` for details.
 #[must_use]
 pub const fn compiled_allocator() -> AllocatorKind {
-    if cfg!(all(feature = "jemalloc", not(target_env = "msvc"))) {
+    if cfg!(all(
+        feature = "jemalloc",
+        not(target_env = "msvc"),
+        not(target_os = "freebsd")
+    )) {
         AllocatorKind::Jemalloc
     } else {
         AllocatorKind::System


### PR DESCRIPTION
Fixes #57

## What this fixes

Resolves the SIGSEGV reported as #57 (and elaborated in the [follow-up comment](https://github.com/Dicklesworthstone/pi_agent_rust/issues/57#issuecomment-4330390820) with the full lldb backtrace).

Root cause: FreeBSD's libc malloc is itself jemalloc-derived. Installing `tikv-jemallocator` via `#[global_allocator]` on FreeBSD therefore puts a **second jemalloc instance** into the same process. The two allocators' metadata regions interfere and cause silent heap corruption that manifests at the next allocator touch — typically `pthread_attr_init` during a fresh thread spawn, called from Rust stdlib's stack-overflow guard init.

## The change

Two-line cfg additions in `src/lib.rs` and `src/perf_build.rs`. The cfg gate that decides whether to register `tikv_jemallocator::Jemalloc` as the global allocator now also requires `not(target_os = "freebsd")`:

```diff
-#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
+#[cfg(all(
+    feature = "jemalloc",
+    not(target_env = "msvc"),
+    not(target_os = "freebsd")
+))]
 #[global_allocator]
 static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
```

Same change in `perf_build::compiled_allocator()` so runtime introspection reports correctly.

`tikv-jemallocator` stays in the dep graph (no Cargo.toml changes); only the `#[global_allocator]` registration is suppressed on FreeBSD. Linux and macOS behavior is unchanged.

## How it was reproduced and verified

**Crash repro** (with the existing default features that include jemalloc):

- pi 0.1.13 / `cargo build --profile debugrelease` (default features) on FreeBSD 15.0-RELEASE-p5.
- Run `pi.debugrelease` interactively with `c137-mem` extension loaded (a small HTTP-using JS extension).
- Use normally for ~10–20 minutes — the SIGSEGV reliably appears.
- Core file shows the manifestation backtrace through `stack_overflow.rs:582 → pthread_attr_init → libc internals → SEGV`. Detailed backtrace in the issue #57 follow-up comment linked above.

**Fix verified**:

- Same `cargo build --profile debugrelease` but with `--no-default-features --features image-resize,clipboard,wasm-host,sqlite-sessions` (i.e. jemalloc dropped). 0 jemalloc symbols in the resulting binary.
- Same interactive workload, ~30+ minutes of normal use, no crash.
- User additionally observed the build "feels noticeably faster" — consistent with the double-jemalloc hypothesis (the two allocators were contending for heap-state locks even before either side corrupted anything).

The committed cfg-gate produces equivalent behavior to `--no-default-features` for the FreeBSD case, with the cleaner property that Linux/macOS users keep the jemalloc default and FreeBSD users automatically get the system allocator.

## Trade-offs

- `tikv-jemallocator` and `tikv-jemalloc-sys` still get compiled into FreeBSD builds (small build-time and binary-size cost) even though they're not used. The alternative — making the default feature list target-aware — is harder in cargo without breaking the simple feature-flag UX.
- If `tikv-jemalloc-sys`'s C build itself ever breaks on FreeBSD (it builds today), that would re-emerge as a separate concern.

## What this does NOT cover

The pi #57 follow-up partial-falsification of the AMAC compat-lane HTTP path is informative but unrelated to this fix. AMAC compat-lane was not the corrupter; the double-jemalloc was. The HTTP path remains as-is.

## Related

- #57 — the original SIGSEGV report
- [#57 issuecomment-4323840881](https://github.com/Dicklesworthstone/pi_agent_rust/issues/57#issuecomment-4323840881) — earlier follow-up (timer-wheel hypothesis falsified)
- [#57 issuecomment-4330390820](https://github.com/Dicklesworthstone/pi_agent_rust/issues/57#issuecomment-4330390820) — fresh lldb backtrace, AMAC compat-lane partial falsification, request for ASan build (this PR supersedes that ASan request — we found the cause via hypothesis-test instead)
