### PR TITLE
update(models): add claude-opus-4-7 to anthropic provider snapshot

### DIFF
--- a/docs/provider-upstream-model-ids-snapshot.json
+++ b/docs/provider-upstream-model-ids-snapshot.json
@@ -2692,6 +2692,7 @@
     "claude-opus-4-5",
     "claude-opus-4-5-20251101",
     "claude-opus-4-6",
+    "claude-opus-4-7",
     "claude-sonnet-4-0",
     "claude-sonnet-4-20250514",
     "claude-sonnet-4-5",


### PR DESCRIPTION
## What this adds

Adds `claude-opus-4-7` to the `anthropic` provider section of `docs/provider-upstream-model-ids-snapshot.json` so Opus 4.7 appears in the `/model` listing.

## Verification

- The `claude-opus-4-7` alias is accepted by Anthropic's API today (verified via direct API call). Users can already select it from a running pi via `/model anthropic/claude-opus-4-7` — that just works because the model name passes through to the provider. The only gap is that the listing doesn't include it.
- One-line addition to the alphabetically-sorted list, matching the pattern of d6fae73d (the gpt-5.3-codex addition).

## Scope

`anthropic` section only. Other providers (Bedrock, Vertex, OpenRouter, Azure, Cloudflare AI Gateway, etc.) carry opus-4-6 entries today but will need separate additions when those providers actually offer opus-4-7. Adding it across all 17 providers without verifying real availability could cause routing failures, so I kept the scope tight.

## Related

Filing a separate feature-request issue alongside this for runtime model-list refresh + user-overridable config — the manual-snapshot-edit pattern is friction that recurs every time a new model ships, and there are design ways to make it self-service. Linking from this PR's discussion once the FR is up. Want to keep the PR scope to just the data addition.
