### PR TITLE
fix(bash-tool): reset SIGPIPE to default in spawned children

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ url = "2"
 
 # Signals
 ctrlc = "3.5.2"
+libc = "0.2"
 
 # Serialization
 serde = { version = "1", features = ["derive", "rc"] }
@@ -313,7 +314,7 @@ debug = 1
 strip = false
 
 [lints.rust]
-unsafe_code = "forbid"
+unsafe_code = "deny"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! - [`PiResult`]
 //! - [`sdk`] module
 
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![allow(dead_code, clippy::unused_async, unused_attributes)]
 #![cfg_attr(
     test,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -5175,11 +5175,31 @@ fn collect_process_tree(
     }
 }
 
+#[allow(unsafe_code)]
 pub(crate) fn isolate_command_process_group(command: &mut Command) {
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt as _;
         command.process_group(0);
+
+        // Reset SIGPIPE to default in the child. Pi's async runtime
+        // (asupersync, like tokio) sets SIGPIPE=SIG_IGN at startup so
+        // internal pipe-write failures don't kill the agent. That signal
+        // disposition is inherited across exec, so spawned children
+        // inherit SIG_IGN — meaning when pi closes its read end of the
+        // child's stdout (e.g. because output exceeded a limit), the
+        // child gets endless EPIPE on writes instead of being terminated
+        // by SIGPIPE. The child loops forever and pi blocks on wait4.
+        //
+        // SAFETY: pre_exec runs in the child between fork and exec.
+        // Only async-signal-safe calls are permitted. signal(2) is on
+        // the POSIX async-signal-safe list.
+        unsafe {
+            command.pre_exec(|| {
+                libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+                Ok(())
+            });
+        }
     }
 
     #[cfg(not(unix))]


### PR DESCRIPTION
## Summary

Pi's `bash` tool (and any other tool that spawns children via `isolate_command_process_group`) hangs indefinitely when a spawned command produces output larger than pi's reader can drain — e.g. asking the model to run `fd` or `ls -R` from a deep directory tree.

## Root cause

Pi's async runtime (asupersync, same as tokio) installs `SIGPIPE=SIG_IGN` at startup so internal pipe-write failures don't terminate the agent. That signal disposition is **inherited across exec**, so every child pi spawns inherits `SIG_IGN` for SIGPIPE.

When pi closes its read end of the child's stdout (because output exceeded a configured limit, or because pi itself is shutting down), the child no longer receives `SIGPIPE` as a signal — it receives `EPIPE` as an errno on every `write(2)` call. Many well-behaved CLI tools (`fd`, `ls`, `find`, GNU coreutils with default settings, etc.) treat `EPIPE` as a recoverable I/O error and continue. They loop forever; pi blocks on `wait4` indefinitely.

This is a known footgun in any Rust async runtime that spawns external commands — the Tokio docs explicitly warn about it.

## Diagnostic evidence

Truss on FreeBSD 15 against pi 0.1.13 with the user-reported repro (a `fd` invocation produced via the bash tool):

```
64278: write(1, "src/public_github/asupersync/src"..., 8188) ERR#32 'Broken pipe'
64278: getdirentries(...) = 96 (0x60)
64278: write(1, "...", 8188) ERR#32 'Broken pipe'
[repeating endlessly until manual SIGINT — 220MB of log]
64278: SIGNAL 2 (SIGINT) code=SI_KERNEL
64278: process killed, signal = 2
```

The child gets `EPIPE` on every write, never gets `SIGPIPE` (because it's ignored), never exits.

## Fix

In `isolate_command_process_group` (the existing helper used by all child-spawn sites), restore `SIGPIPE` to `SIG_DFL` via `Command::pre_exec` between fork and exec:

```rust
unsafe {
    command.pre_exec(|| {
        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
        Ok(())
    });
}
```

`signal(2)` is async-signal-safe per POSIX, satisfying `pre_exec`'s contract. The `SAFETY` comment in the diff documents this.

## Lint policy change

The workspace `[lints.rust] unsafe_code = "forbid"` and `lib.rs`'s `#![forbid(unsafe_code)]` are both downgraded to `deny`, allowing a single `#[allow(unsafe_code)]` on this helper. No other `unsafe` blocks exist in the crate.

If you'd prefer to keep `forbid` and accept the cost, a layered design (e.g. a separate small `pi-spawn-helpers` sub-crate that hosts only the pre_exec helper without `forbid`) would also work — happy to refactor that direction if you'd rather.

## Verification

Tested on FreeBSD 15.0-RELEASE-p5, pi built from this branch:

```
pi --provider openrouter --model deepseek/deepseek-v4-flash --mode text \
    -p 'Use the bash tool to run "fd . /home/tcovert/scratch 2>/dev/null" \
        and tell me approximately how many files there are.'
# returns within ~10s with: "There are **17,451 files** in `/home/tcovert/scratch`."
```

Same workload that previously hung indefinitely now returns cleanly within ~10 seconds. The bash tool delivers the result count to the model and pi exits.

## Cargo.lock

Not included — adds `libc = "0.2"` as a direct dependency (already in the workspace transitively). `cargo update -p libc` after merge will regenerate it cleanly. Happy to include the lockfile update if you'd prefer.

## Scope

This fixes the bash tool spawn site (the user-reported hang). The same pattern applies to any other child-spawn site in pi — the `grep` tool spawning `rg`, the `find` tool spawning `fd`, etc. — but those don't use `isolate_command_process_group` today, and I scoped this PR to the minimum diff that closes the user-reported issue. Happy to extend to those other spawn sites in a follow-up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)