### PR TITLE
feat(install): add --source-dir flag for local-source builds

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,7 @@ AGENT_SKILLS_ENABLED="${AGENT_SKILLS_ENABLED:-1}"
 CHECKSUM="${CHECKSUM:-}"
 CHECKSUM_URL="${CHECKSUM_URL:-}"
 ARTIFACT_URL="${ARTIFACT_URL:-}"
+SOURCE_DIR="${SOURCE_DIR:-}"
 SIGSTORE_BUNDLE_URL="${SIGSTORE_BUNDLE_URL:-}"
 COSIGN_IDENTITY_RE="${COSIGN_IDENTITY_RE:-^https://github.com/${OWNER}/${REPO}/.github/workflows/release.yml@refs/tags/.*$}"
 COSIGN_OIDC_ISSUER="${COSIGN_OIDC_ISSUER:-https://token.actions.githubusercontent.com}"
@@ -649,6 +650,10 @@ Options:
   --sigstore-bundle-url URL
                           URL to Sigstore bundle (.sigstore.json)
   --from-source          Build from source instead of downloading release binary
+  --source-dir DIR       Build from a local pi_agent_rust checkout instead of cloning;
+                          implies --from-source. Useful when iterating locally,
+                          when the desired commit isn't tagged, or on platforms
+                          without prebuilt binaries (e.g. FreeBSD).
   --verify               Run `pi --version` after install
   --no-verify            Skip checksum + signature verification
   --offline [TARBALL]    Offline mode; optional local artifact path
@@ -736,6 +741,16 @@ while [ $# -gt 0 ]; do
     --from-source)
       FROM_SOURCE=1
       shift
+      ;;
+    --source-dir)
+      if [ $# -lt 2 ]; then
+        err "Option --source-dir requires a value"
+        usage
+        exit 1
+      fi
+      SOURCE_DIR="$2"
+      FROM_SOURCE=1
+      shift 2
       ;;
     --verify)
       VERIFY=1
@@ -1195,8 +1210,8 @@ validate_options() {
     exit 1
   fi
 
-  if [ "$OFFLINE" -eq 1 ] && [ "$FROM_SOURCE" -eq 1 ]; then
-    err "--offline cannot be combined with --from-source (source build needs network access)"
+  if [ "$OFFLINE" -eq 1 ] && [ "$FROM_SOURCE" -eq 1 ] && [ -z "$SOURCE_DIR" ]; then
+    err "--offline cannot be combined with --from-source unless --source-dir is also set (the clone step needs network access)"
     exit 1
   fi
 
@@ -1760,13 +1775,35 @@ download_release_binary() {
 }
 
 build_from_source() {
-  if [ "$OFFLINE" -eq 1 ]; then
-    err "Offline mode cannot build from source (network access required)"
-    return 1
+  local src_dir
+
+  if [ -n "$SOURCE_DIR" ]; then
+    # Local-source build path: skip the clone, validate the directory, build in place.
+    if [ ! -d "$SOURCE_DIR" ]; then
+      err "--source-dir path does not exist or is not a directory: $SOURCE_DIR"
+      return 1
+    fi
+    src_dir=$(cd "$SOURCE_DIR" && pwd) || {
+      err "Could not resolve --source-dir path: $SOURCE_DIR"
+      return 1
+    }
+    if [ ! -f "$src_dir/Cargo.toml" ]; then
+      err "--source-dir does not contain Cargo.toml: $src_dir"
+      return 1
+    fi
+    if ! grep -q '^name *= *"pi_agent_rust"' "$src_dir/Cargo.toml"; then
+      err "--source-dir does not look like a pi_agent_rust checkout (Cargo.toml package name mismatch): $src_dir"
+      return 1
+    fi
+  else
+    if [ "$OFFLINE" -eq 1 ]; then
+      err "Offline mode cannot build from source (network access required)"
+      return 1
+    fi
+    src_dir="$TMP/src"
+    git clone --depth 1 --branch "$VERSION" "https://github.com/${OWNER}/${REPO}.git" "$src_dir" >&2
   fi
 
-  local src_dir="$TMP/src"
-  git clone --depth 1 --branch "$VERSION" "https://github.com/${OWNER}/${REPO}.git" "$src_dir" >&2
   (cd "$src_dir" && cargo build --release --locked --bin pi >&2)
 
   local built_bin="$src_dir/target/release/pi${EXE_EXT}"


### PR DESCRIPTION
## Summary

`install.sh --from-source` always does `git clone --depth 1 --branch \"\$VERSION\" https://github.com/.../pi_agent_rust.git`, even when run from inside an existing checkout. That means anyone iterating on local changes has to either tag-and-push every iteration, or skip install.sh entirely (losing the agent-skills + shell-completions bootstrap).

This PR adds `--source-dir DIR` to point install.sh at a local checkout instead. The flag implies `--from-source` and replaces the clone step with a path-validation pass; the rest of the build flow (`cargo build --release --locked --bin pi`) is unchanged.

## Motivation

I've been doing FreeBSD work on pi_agent_rust. FreeBSD has no prebuilt release binaries, so every FreeBSD user falls into `--from-source` and re-clones from upstream `main`. When there are local patches not yet merged, the re-clone discards them, and the user loses the install.sh-managed setup. Tagging every WIP iteration is heavy.

The flag generalizes nicely beyond FreeBSD — anyone working on a feature branch or testing a downstream patch hits the same friction.

## Changes

- `SOURCE_DIR=\"\${SOURCE_DIR:-}\"` added to the env-default block.
- `--source-dir DIR` flag in argument parser (implies `--from-source`).
- `--source-dir DIR` row in `--help` output.
- `build_from_source()` branches on `SOURCE_DIR`:
  - if set → validate it's a directory containing `Cargo.toml` with `name = \"pi_agent_rust\"`, then build in place
  - if unset → existing clone-then-build path, unchanged
- `--offline + --from-source` incompatibility now permits `--offline + --source-dir` (the clone step needed network; a local checkout doesn't).

## Backward compatibility

Default behavior unchanged: without `--source-dir`, the clone path runs as before. No env-var or flag interactions are altered for callers that don't opt in.

## Validation

- `bash -n install.sh` — clean
- `./install.sh --help` — new flag listed
- Error paths exercised manually:
  - `--source-dir /nonexistent` → `'--source-dir path does not exist or is not a directory'`
  - `--source-dir /tmp` (no Cargo.toml) → `'--source-dir does not contain Cargo.toml'`
  - `--source-dir <wrong cargo project>` → `'package name mismatch'`

## Usage

```bash
# From inside a checkout
./install.sh --source-dir .

# From elsewhere
./install.sh --source-dir ~/src/pi_agent_rust

# Combined with --offline (now allowed)
./install.sh --source-dir . --offline
```

## Test plan

- [x] Syntax-check: \`bash -n install.sh\`
- [x] Help output shows the new flag
- [x] Error paths print clear messages
- [ ] Maintainer end-to-end test on Linux (existing CI presumably covers this; the changed function preserves the existing path when --source-dir is empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)