### PR TITLE
feat(tools/read): allow reading from configured agent dir, not only cwd

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -737,6 +737,50 @@ fn enforce_cwd_scope(path: &Path, cwd: &Path, action: &str) -> Result<PathBuf> {
     Ok(canonical_path)
 }
 
+/// Same as `enforce_cwd_scope` but also permits paths under the supplied
+/// agent directory (typically `~/.pi/agent/`, overridable via
+/// PI_CODING_AGENT_DIR).
+///
+/// Used for the `read` tool so the agent can load its own resource files
+/// (skills, prompt templates, themes) which live under the agent dir, not
+/// under the user's project cwd. Symlink escapes are still blocked because
+/// `safe_canonicalize` resolves symlinks before the prefix check.
+///
+/// Other tools (write, edit, grep, find, ls, hashline_edit) keep using
+/// `enforce_cwd_scope` and remain strictly cwd-only — broadening write
+/// access would let a misbehaving model persist instructions into the
+/// agent dir, which is more risk than the read case warrants.
+fn enforce_read_scope_with_agent_dir(
+    path: &Path,
+    cwd: &Path,
+    agent_dir: &Path,
+) -> Result<PathBuf> {
+    let canonical_path = crate::extensions::safe_canonicalize(path);
+    let canonical_cwd = crate::extensions::safe_canonicalize(cwd);
+    if canonical_path.starts_with(&canonical_cwd) {
+        return Ok(canonical_path);
+    }
+
+    let canonical_agent_dir = crate::extensions::safe_canonicalize(agent_dir);
+    if canonical_path.starts_with(&canonical_agent_dir) {
+        return Ok(canonical_path);
+    }
+
+    Err(Error::validation(format!(
+        "Cannot read outside the working directory or agent dir \
+         (resolved: {}, cwd: {}, agent dir: {})",
+        canonical_path.display(),
+        canonical_cwd.display(),
+        canonical_agent_dir.display()
+    )))
+}
+
+/// Convenience wrapper that pulls the agent dir from the active config.
+fn enforce_read_scope(path: &Path, cwd: &Path) -> Result<PathBuf> {
+    let agent_dir = crate::config::Config::global_dir();
+    enforce_read_scope_with_agent_dir(path, cwd, &agent_dir)
+}
+
 // ============================================================================
 // CLI @file Processor (used by src/main.rs)
 // ============================================================================
@@ -954,7 +998,7 @@ pub fn process_file_arguments(
     for file_arg in file_args {
         let resolved = resolve_read_path(file_arg, cwd);
         let absolute_path = normalize_dot_segments(&resolved);
-        let absolute_path = enforce_cwd_scope(&absolute_path, cwd, "read")?;
+        let absolute_path = enforce_read_scope(&absolute_path, cwd)?;
 
         let meta = std::fs::metadata(&absolute_path).map_err(|e| {
             Error::tool(
@@ -1473,7 +1517,7 @@ impl Tool for ReadTool {
         }
 
         let path = resolve_read_path(&input.path, &self.cwd);
-        let path = enforce_cwd_scope(&path, &self.cwd, "read")?;
+        let path = enforce_read_scope(&path, &self.cwd)?;
 
         let meta = asupersync::fs::metadata(&path).await.ok();
         if let Some(meta) = &meta {
@@ -6460,6 +6504,45 @@ mod tests {
                 .unwrap_err();
             assert!(err.to_string().contains("outside the working directory"));
         });
+    }
+
+    #[test]
+    fn test_enforce_read_scope_allows_agent_dir_outside_cwd() {
+        // Skills, prompt templates, and themes live under the agent dir
+        // (`~/.pi/agent/` by default). The agent legitimately needs to read
+        // these even when cwd is a user project directory on a different
+        // path. Verify enforce_read_scope_with_agent_dir accepts a file
+        // under the agent dir even when it is NOT a descendant of cwd.
+        let cwd = tempfile::tempdir().unwrap();
+        let agent_dir = tempfile::tempdir().unwrap();
+        let skill_dir = agent_dir.path().join("skills").join("example");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let skill_path = skill_dir.join("SKILL.md");
+        std::fs::write(&skill_path, "---\nname: example\n---\nhi\n").unwrap();
+
+        let result = enforce_read_scope_with_agent_dir(&skill_path, cwd.path(), agent_dir.path());
+        assert!(
+            result.is_ok(),
+            "expected read scope to allow file under agent dir, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_enforce_read_scope_still_rejects_unrelated_paths() {
+        // Sanity check: the new agent-dir allowance is additive. Paths
+        // outside BOTH cwd and agent_dir must still be rejected.
+        let cwd = tempfile::tempdir().unwrap();
+        let agent_dir = tempfile::tempdir().unwrap();
+        let unrelated = tempfile::tempdir().unwrap();
+        std::fs::write(unrelated.path().join("secret.txt"), "secret").unwrap();
+        let secret_path = unrelated.path().join("secret.txt");
+
+        let err = enforce_read_scope_with_agent_dir(&secret_path, cwd.path(), agent_dir.path())
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("outside the working directory"),
+            "expected validation error, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `read` tool's path validation rejects any path that isn't a descendant of the cwd, with a `Cannot read outside the working directory` error. That's correct as a path-traversal defense — but it has a side effect: pi cannot read its own resource files.

Concretely: when pi auto-loads a skill into the system prompt, the model sees the one-line description and is instructed to fetch the SKILL.md body via the read tool when relevant. Skills live at `~/.pi/agent/skills/<name>/SKILL.md` (per the agentskills.io spec). That path is neither an ancestor nor a descendant of any user project cwd, so the read fails. The model then falls back to a bash `cat`, which works but reports as a tool-error in the TUI and is awkward.

## Reproduction

On any pi-rust install with at least one skill present:

```
$ cd ~/some-project   # any cwd that isn't ~/.pi/agent/
$ pi
> can you tell me what you know about my freebsd jails skill?
```

The model attempts a read tool call against `~/.pi/agent/skills/freebsd-jails/SKILL.md` and gets `Error: Validation error: Cannot read outside the working directory ...`. Conversation continues via bash fallback, but the TUI shows the read error.

## Fix

Add a read-only scope expansion: paths under the configured agent dir (`Config::global_dir()`, default `~/.pi/agent/`, overridable via `PI_CODING_AGENT_DIR`) are now permitted by the read tool. Other tools (write, edit, grep, find, ls, hashline_edit) remain strictly cwd-only — broadening write access would let a misbehaving model persist instructions into the agent dir, which is more risk than the read case warrants.

Symlink escapes are still blocked because `safe_canonicalize` resolves symlinks before the prefix check; e.g. a symlink at `~/.pi/agent/skills/foo/SKILL.md` -> `/etc/passwd` canonicalizes to `/etc/passwd` which then fails the prefix test against both cwd and agent_dir.

## Implementation

- New `enforce_read_scope_with_agent_dir(path, cwd, agent_dir)` accepts either cwd OR agent_dir as a valid root.
- Convenience wrapper `enforce_read_scope(path, cwd)` pulls agent_dir from `Config::global_dir()`.
- The two read-action callsites in `tools.rs` (CLI `@file` processing path at line ~991 and the live `ReadTool::execute` at line ~1510) switch to the new function.
- Two unit tests added next to the existing `test_read_rejects_outside_cwd`:
  - `test_enforce_read_scope_allows_agent_dir_outside_cwd` — positive: file under agent_dir is allowed even when cwd is unrelated.
  - `test_enforce_read_scope_still_rejects_unrelated_paths` — negative: path outside BOTH cwd and agent_dir is still rejected.

## Tradeoffs considered

- **Why parameter rather than env-var-based config inside the function?** Simpler to test, doesn't require `unsafe { std::env::set_var(...) }` blocks (which are blocked by `#![forbid(unsafe_code)]`). The convenience wrapper preserves the production call shape.
- **Why not also allow grep/find under agent dir?** Could be a follow-up. For now, the bug-driver was specifically the read path; grep/find under agent dir is a different feature with its own design questions (e.g. should searches DEFAULT to including agent dir, or only when explicitly targeted?).
- **Why not a user-configurable allowlist file?** Could be a follow-up too. The agent dir is the universal case; per-user allowlists handle project-specific overrides and need their own loading/validation surface. Better split.

## Validation

- `cargo check --tests --lib --release` clean on FreeBSD 15.
- New tests pass; existing `test_read_rejects_outside_cwd` unchanged and still passing.
- Reproduced the original issue on pi-rust 0.1.15 (FreeBSD 15) reading a SKILL.md from a project cwd; with the patch the read succeeds without falling back to bash.

## Test plan

- [x] `cargo check --tests --lib --release` clean
- [x] Two new unit tests pass
- [x] Existing `test_read_rejects_outside_cwd` still passes
- [ ] Maintainer verifies on Linux: existing behavior preserved when path is unrelated to either cwd or agent dir; agent-dir reads succeed when path matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)