### PR TITLE
feat(http): allow plain http for loopback when PI_HTTP_ALLOW_LOOPBACK=1

### DIFF
--- a/src/connectors/http.rs
+++ b/src/connectors/http.rs
@@ -75,6 +75,28 @@ fn invalid_request(call_id: &str, message: impl Into<String>) -> HostResultPaylo
     host_result_err(call_id, HostCallErrorCode::InvalidRequest, message, None)
 }
 
+/// Developer opt-in: when set to "1", plain http:// is permitted for
+/// loopback hosts only. Default behavior (require TLS) is unchanged.
+fn allow_loopback_http_env() -> bool {
+    std::env::var("PI_HTTP_ALLOW_LOOPBACK")
+        .ok()
+        .as_deref()
+        == Some("1")
+}
+
+/// True when host is a loopback address. Matches 127.0.0.0/8, ::1,
+/// localhost, and bracketed forms used in URL parsing.
+fn is_loopback_host(host: &str) -> bool {
+    let h = host.trim().trim_start_matches('[').trim_end_matches(']');
+    if h.eq_ignore_ascii_case("localhost") || h == "::1" {
+        return true;
+    }
+    if let Ok(ip) = h.parse::<std::net::IpAddr>() {
+        return ip.is_loopback();
+    }
+    false
+}
+
 fn io_error(call_id: &str, message: impl Into<String>) -> HostResultPayload {
     host_result_err(call_id, HostCallErrorCode::Io, message, None)
 }
@@ -294,12 +316,18 @@ impl HttpConnector {
 
         match parsed.scheme {
             Scheme::Http if self.config.require_tls => {
-                return Err(Box::new(host_result_err(
-                    &call.call_id,
-                    HostCallErrorCode::Denied,
-                    "TLS required: use https:// URLs",
-                    None,
-                )));
+                // Explicit developer opt-in: PI_HTTP_ALLOW_LOOPBACK=1 lets
+                // plain http through ONLY for loopback hosts. Everything
+                // else still requires TLS by default. Intended for local-
+                // worker development where setting up a cert is friction.
+                if !(allow_loopback_http_env() && is_loopback_host(&parsed.host)) {
+                    return Err(Box::new(host_result_err(
+                        &call.call_id,
+                        HostCallErrorCode::Denied,
+                        "TLS required: use https:// URLs (set PI_HTTP_ALLOW_LOOPBACK=1 for local development)",
+                        None,
+                    )));
+                }
             }
             Scheme::Http | Scheme::Https => {}
         }


### PR DESCRIPTION
## Summary

Adds an opt-in `PI_HTTP_ALLOW_LOOPBACK=1` env var that permits plain HTTP for loopback addresses (127.0.0.0/8, `::1`, `localhost`) while preserving the existing TLS-required default for everything else.

## Motivation

`HttpConnectorConfig::default()` has `require_tls: true`, which is correct for general-purpose HTTP from extensions. However, every production callsite that creates an `HttpConnector` for extension dispatch uses this default, and there is no escape hatch for extensions that legitimately need to talk to a local worker over plain HTTP.

Concrete case: I run a small local memory-indexing worker (think: SQLite + JSONL + a thin axum HTTP API) on `127.0.0.1:37778`. A pi extension talks to it for cross-session memory injection at session start. Setting up TLS termination for a one-process localhost-only service is real friction — self-signed certs, trust-store config, rebuilding the extension's HTTP client, etc.

The browser security model treats loopback as a "secure context" available over plain HTTP for exactly this reason. This patch lets pi opt-in to the same model.

## Design

- New helper `allow_loopback_http_env()` reads `PI_HTTP_ALLOW_LOOPBACK`; returns `true` only when value is exactly `"1"`.
- New helper `is_loopback_host(host)` accepts `localhost`, `::1`, anything in `127.0.0.0/8`, and bracketed IPv6 forms.
- The existing `Scheme::Http if self.config.require_tls` denial branch checks both helpers; only bypasses the rejection when both are true.
- Error message updated to mention the env var as a hint.

Behaviour preserved when env var unset:
- Plain HTTP to non-loopback: still denied.
- Plain HTTP to loopback: still denied.
- HTTPS to anything allowed by allowlist: still allowed.

Behaviour when env var set to "1":
- Plain HTTP to loopback: allowed.
- Everything else unchanged.

## Why this shape (vs. always-allow loopback, or a config field)

- **Always-allow-loopback by default** is too aggressive: a downstream user might run an extension that hits a malicious-but-loopback endpoint. The env-var opt-in keeps the secure default while making the loosening explicit and easy to audit.
- **Config-file field** would work too, but env vars are easier to flip per-shell and per-project, which fits the use case (developer convenience for local-extension dev).

## Verification

- `cargo check --bin pi`: passes.
- `cargo build --release --bin pi`: passes.
- Manual: with env var set, c137-mem extension's plain-HTTP call to `127.0.0.1:37778` succeeds. Without env var, returns the existing `TLS required` error.
- Defense-in-depth preserved: I had `PI_HTTP_ALLOW_LOOPBACK` set in zsh env for a week before realizing the binary I was running was unpatched and was correctly refusing the call.

## What this does not do

- Does not add a denylist for specific loopback ports (would be over-engineering for the use case).
- Does not address worker-side TLS termination as the architecturally cleaner answer (filed as a separate downstream issue: setting up FreeBSD install with localhost certs so HTTPS-by-default works).

## Notes

This is the second batch of FreeBSD-portability-related patches to pi_agent_rust. The first batch (#67-#71) all closed-and-reimplemented under maintainer commits — happy with that pattern, no merge expected, just good-faith contribution.