### PR TITLE
fix(model): accept `redacted_thinking` content blocks from Anthropic-compatible providers

### DIFF
--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -427,6 +427,7 @@ fn estimate_tokens(message: &SessionMessage) -> u64 {
                             chars = chars.saturating_add(call.name.len());
                             chars = chars.saturating_add(json_byte_len(&call.arguments));
                         }
+                        ContentBlock::RedactedThinking(_) => {}
                     }
                 }
             }
@@ -447,6 +448,7 @@ fn estimate_tokens(message: &SessionMessage) -> u64 {
                         chars = chars.saturating_add(call.name.len());
                         chars = chars.saturating_add(json_byte_len(&call.arguments));
                     }
+                    ContentBlock::RedactedThinking(_) => {}
                 }
             }
         }
@@ -466,6 +468,7 @@ fn estimate_tokens(message: &SessionMessage) -> u64 {
                         chars = chars.saturating_add(call.name.len());
                         chars = chars.saturating_add(json_byte_len(&call.arguments));
                     }
+                    ContentBlock::RedactedThinking(_) => {}
                 }
             }
         }
@@ -704,6 +707,7 @@ fn assistant_content_flags(assistant: &AssistantMessage) -> (bool, bool, bool) {
             ContentBlock::Text(_) => has_text = true,
             ContentBlock::ToolCall(_) => has_tools = true,
             ContentBlock::Image(_) => {}
+            ContentBlock::RedactedThinking(_) => {}
         }
     }
     (has_thinking, has_text, has_tools)

--- a/src/interactive/conversation.rs
+++ b/src/interactive/conversation.rs
@@ -52,6 +52,7 @@ pub(super) fn content_blocks_to_text(blocks: &[ContentBlock]) -> String {
             ContentBlock::ToolCall(call) => {
                 push_line(&mut output, &format!("[tool call: {}]", call.name));
             }
+            ContentBlock::RedactedThinking(_) => {}
         }
     }
     output
@@ -108,6 +109,7 @@ pub(super) fn tool_content_blocks_to_text(blocks: &[ContentBlock], show_images: 
             ContentBlock::ToolCall(call) => {
                 push_line(&mut output, &format!("[tool call: {}]", call.name));
             }
+            ContentBlock::RedactedThinking(_) => {}
         }
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -139,6 +139,9 @@ pub enum ContentBlock {
     Text(TextContent),
     /// Provider “thinking” / reasoning (if enabled).
     Thinking(ThinkingContent),
+    /// Provider-redacted thinking marker with opaque data.
+    #[serde(rename = "redacted_thinking")]
+    RedactedThinking(RedactedThinkingContent),
     /// An inline image (base64 + MIME type).
     Image(ImageContent),
     /// A request to call a tool with JSON arguments.
@@ -170,6 +173,13 @@ pub struct ThinkingContent {
     pub thinking: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thinking_signature: Option<String>,
+}
+
+/// Redacted thinking marker content block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RedactedThinkingContent {
+    pub data: String,
 }
 
 /// Image content block.
@@ -876,6 +886,61 @@ mod tests {
         let json = serde_json::to_string(&block).expect("serialize");
         let parsed: ContentBlock = serde_json::from_str(&json).expect("deserialize");
         assert!(matches!(parsed, ContentBlock::Thinking(t) if t.thinking == "reasoning..."));
+    }
+
+    #[test]
+    fn content_block_redacted_thinking_roundtrip() {
+        // OpenRouter (and Anthropic for safety-redacted thinking) emit
+        // {"type":"redacted_thinking","data":"<opaque>"} blocks. pi must
+        // accept them without crashing the deserializer.
+        let json_in = json!({"type": "redacted_thinking", "data": "OPAQUE_REDACTION_BLOB"});
+        let parsed: ContentBlock = serde_json::from_value(json_in).expect("deserialize");
+        match &parsed {
+            ContentBlock::RedactedThinking(rt) => {
+                assert_eq!(rt.data, "OPAQUE_REDACTION_BLOB");
+            }
+            _ => panic!("expected RedactedThinking variant, got {parsed:?}"),
+        }
+        // Round-trip preserves the data field on re-serialization.
+        let reserialized = serde_json::to_value(&parsed).expect("re-serialize");
+        assert_eq!(reserialized["type"], "redacted_thinking");
+        assert_eq!(reserialized["data"], "OPAQUE_REDACTION_BLOB");
+    }
+
+    #[test]
+    fn content_block_redacted_thinking_in_assistant_message() {
+        // Mixed content: text + redacted_thinking + text. Round-trip through
+        // serde to exercise the deserializer on a realistic message shape —
+        // the kind OpenRouter sends back when its upstream produced redacted reasoning.
+        let original = AssistantMessage {
+            content: vec![
+                ContentBlock::Text(TextContent::new("Before.")),
+                ContentBlock::RedactedThinking(RedactedThinkingContent {
+                    data: "REDACTED".to_string(),
+                }),
+                ContentBlock::Text(TextContent::new("After.")),
+            ],
+            ..AssistantMessage::default()
+        };
+        let serialized = serde_json::to_value(&original).expect("serialize");
+        let parsed: AssistantMessage = serde_json::from_value(serialized).expect("deserialize");
+        assert_eq!(parsed.content.len(), 3);
+        assert!(matches!(parsed.content[0], ContentBlock::Text(_)));
+        assert!(matches!(parsed.content[1], ContentBlock::RedactedThinking(_)));
+        assert!(matches!(parsed.content[2], ContentBlock::Text(_)));
+    }
+
+    #[test]
+    fn content_block_redacted_thinking_unknown_field_tolerated() {
+        // Forward compatibility: if Anthropic ever adds a sibling field
+        // (e.g. a marker_id) we should still deserialize the block, not panic.
+        let json = json!({
+            "type": "redacted_thinking",
+            "data": "OPAQUE",
+            "futureFieldFromUpstream": "ignore me"
+        });
+        let parsed: ContentBlock = serde_json::from_value(json).expect("deserialize");
+        assert!(matches!(parsed, ContentBlock::RedactedThinking(_)));
     }
 
     #[test]

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -7,8 +7,8 @@ use crate::auth::unmark_anthropic_oauth_bearer_token;
 use crate::error::{Error, Result};
 use crate::http::client::Client;
 use crate::model::{
-    AssistantMessage, ContentBlock, Message, StopReason, StreamEvent, TextContent, ThinkingContent,
-    ThinkingLevel, ToolCall, Usage, UserContent,
+    AssistantMessage, ContentBlock, Message, RedactedThinkingContent, StopReason, StreamEvent,
+    TextContent, ThinkingContent, ThinkingLevel, ToolCall, Usage, UserContent,
 };
 use crate::models::CompatConfig;
 use crate::provider::{CacheRetention, Context, Provider, StreamOptions, ToolDef};
@@ -791,6 +791,12 @@ where
                 }));
                 StreamEvent::ToolCallStart { content_index }
             }
+            AnthropicContentBlock::RedactedThinking { data } => {
+                self.partial
+                    .content
+                    .push(ContentBlock::RedactedThinking(RedactedThinkingContent { data }));
+                StreamEvent::ThinkingStart { content_index }
+            }
         }
     }
 
@@ -906,6 +912,10 @@ where
                     None
                 }
             }
+            Some(ContentBlock::RedactedThinking(_)) => Some(StreamEvent::ThinkingEnd {
+                content_index: idx,
+                content: String::new(),
+            }),
             _ => None,
         }
     }
@@ -1083,6 +1093,10 @@ enum AnthropicContentBlock {
         #[serde(default)]
         name: Option<String>,
     },
+    RedactedThinking {
+        #[serde(default)]
+        data: String,
+    },
 }
 
 /// Per-token delta from the Anthropic streaming API.
@@ -1225,7 +1239,7 @@ fn convert_content_block_to_anthropic(block: &ContentBlock) -> Option<AnthropicC
                     signature: sig,
                 })
         }
-        ContentBlock::Image(_) => None,
+        ContentBlock::Image(_) | ContentBlock::RedactedThinking(_) => None,
     }
 }
 

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -986,7 +986,9 @@ pub(crate) fn convert_message_to_gemini(message: &Message) -> Vec<GeminiContent>
                             },
                         });
                     }
-                    ContentBlock::Thinking(_) | ContentBlock::Image(_) => {
+                    ContentBlock::Thinking(_)
+                    | ContentBlock::Image(_)
+                    | ContentBlock::RedactedThinking(_) => {
                         // Skip thinking blocks and images in assistant output
                     }
                 }

--- a/src/providers/openai_responses.rs
+++ b/src/providers/openai_responses.rs
@@ -1142,7 +1142,7 @@ where
                 ContentBlock::ToolCall(_) => {
                     Some(TerminalContentSnapshot::ToolCall { content_index })
                 }
-                ContentBlock::Image(_) => None,
+                ContentBlock::Image(_) | ContentBlock::RedactedThinking(_) => None,
             })
             .collect()
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -4162,6 +4162,7 @@ fn render_blocks(blocks: &[ContentBlock]) -> String {
                     escape_html(&args)
                 );
             }
+            ContentBlock::RedactedThinking(_) => {}
         }
     }
     html
@@ -4203,6 +4204,7 @@ fn content_blocks_to_text(blocks: &[ContentBlock]) -> String {
             ContentBlock::ToolCall(call) => {
                 push_line(&mut output, &format!("[tool call: {}]", call.name));
             }
+            ContentBlock::RedactedThinking(_) => {}
         }
     }
     output


### PR DESCRIPTION
## What

Adds support for the `redacted_thinking` content-block variant on the wire — `{"type":"redacted_thinking","data":"<opaque>"}` — which Anthropic's safety-redaction path emits and OpenRouter's Anthropic-compatible relay propagates verbatim. Today's deserializer is exhaustive over `text|thinking|tool_use|image` and rejects this variant outright with `unknown variant redacted_thinking`, hard-failing the agent loop on what is otherwise a successful 200 response.

## Why

Caught while exercising a claude-proxy failover path: a thinking-on request was routed through openrouter (because the primary anthropic-OAuth backend was rate-limited), openrouter returned a successful 200 carrying redacted thinking from its upstream, and pi panicked deserializing the response. The block is a deliberate marker — the upstream produced reasoning that the provider chose to redact for safety reasons — and there's no useful text in it to surface, but pi has to accept the type or the agent loop terminates on every redaction.

## Design

Single new variant on `ContentBlock`, with `#[serde(rename = "redacted_thinking")]` to match the wire form, and a small `RedactedThinkingContent` struct holding the opaque `data` field. Match-site updates at every existing exhaustive-pattern point preserve the codebase's per-variant exhaustiveness convention rather than reaching for `#[serde(other)]`.

Per-site behavior:

| Site | Behavior |
|---|---|
| `compaction.rs` (token estimate) | contributes 0 chars (no user text) |
| `interactive/conversation.rs`, `session.rs` (display / render) | skip — opaque data is not user-facing |
| `providers/gemini.rs` (cross-provider conversion) | skip alongside `Thinking` and `Image` |
| `providers/openai_responses.rs` (terminal snapshot) | None |
| `providers/anthropic.rs` (streaming decoder) | parse `AnthropicContentBlock::RedactedThinking { data }` from the wire; emit `StreamEvent::ThinkingStart` / `ThinkingEnd` with empty content; preserve the `RedactedThinkingContent` block on the partial assistant message so the round-trip is faithful |

The streaming-side bracketing as `ThinkingStart`/`ThinkingEnd` keeps the protocol consistent (the redaction *was* thinking from the model's perspective, just not surfaceable), while the empty `content` keeps the redaction redacted.

## Test coverage

Three unit tests in `src/model.rs` (`cargo test --lib content_block`):

- `content_block_redacted_thinking_roundtrip` — canonical wire JSON deserializes; the `data` field round-trips intact through re-serialization.
- `content_block_redacted_thinking_in_assistant_message` — a mixed text/redacted/text content vec serializes and deserializes through `AssistantMessage` without losing variants or order.
- `content_block_redacted_thinking_unknown_field_tolerated` — forward compatibility: extra sibling fields on the wire don't break deserialization.

All 17 `content_block` tests pass; `cargo check --lib --bins` is clean.

## Out of scope (intentional, per the bug-fix-only-PR convention)

- Exposing `RedactedThinking` in JSON / CSV output schemas — opt-in surfacing for downstream tooling is a separate concern.
- Cross-language broker plumbing (c137-blink) — different module, different PR.
- Default-output user-facing rendering changes for the redacted marker — current behavior (skip) matches user expectation; if anyone wants a placeholder badge that's a follow-up.