### PR TITLE
Add GPT 5.6 - Fix CI traceability and publish Linux build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2243,3 +2243,42 @@ jobs:
           # integration tests/benches require the `tui` feature, so they are
           # expected to be skipped here — only the library contract is locked in.
           cargo check --no-default-features --lib
+
+  linux_release_binary:
+    name: Linux release binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CARGO_INCREMENTAL: "0"
+    defaults:
+      run:
+        working-directory: pi_agent_rust
+        shell: bash
+    steps:
+      - name: Checkout pi_agent_rust
+        uses: actions/checkout@v4
+        with:
+          path: pi_agent_rust
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y \
+            libxcb1-dev \
+            libxcb-render0-dev \
+            libxcb-shape0-dev \
+            libxcb-xfixes0-dev
+
+      - name: Install Rust toolchain (nightly)
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Build Linux release binary
+        run: cargo build --release --locked --bin pi
+
+      - name: Upload Linux release binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: pi-linux-x86_64-${{ github.sha }}
+          path: pi_agent_rust/target/release/pi

--- a/docs/e2e_scenario_matrix.json
+++ b/docs/e2e_scenario_matrix.json
@@ -199,11 +199,13 @@
       ],
       "suite_ids": [
         "e2e_message_session_control",
-        "e2e_session_persistence"
+        "e2e_session_persistence",
+        "e2e_transient_retry_resume"
       ],
       "test_paths": [
         "tests/e2e_message_session_control.rs",
-        "tests/e2e_session_persistence.rs"
+        "tests/e2e_session_persistence.rs",
+        "tests/e2e_transient_retry_resume.rs"
       ],
       "sli_ids": [
         "sli.session.resume_ready_ms",
@@ -218,7 +220,7 @@
         "environment.json",
         "evidence_contract.json"
       ],
-      "replay_command": "./scripts/e2e/run_all.sh --profile ci --suite e2e_message_session_control --suite e2e_session_persistence"
+      "replay_command": "./scripts/e2e/run_all.sh --profile ci --suite e2e_message_session_control --suite e2e_session_persistence --suite e2e_transient_retry_resume"
     },
     {
       "workflow_id": "wf-rpc-endpoint-integration",

--- a/docs/traceability_matrix.json
+++ b/docs/traceability_matrix.json
@@ -928,6 +928,10 @@
           "justification": "Classified e2e suite included in the bd-8t27h.3 traceability backfill so CI governance covers all registered tests."
         },
         {
+          "path": "tests/e2e_transient_retry_resume.rs",
+          "justification": "Verifies that transient provider failures resume the incomplete turn without replaying completed tool calls."
+        },
+        {
           "path": "tests/e2e_provider_failure_injection.rs",
           "justification": "Classified e2e suite included in the bd-8t27h.3 traceability backfill so CI governance covers all registered tests."
         },

--- a/src/models.rs
+++ b/src/models.rs
@@ -33,6 +33,9 @@ impl ModelEntry {
             "gpt-5.1-codex-max"
                 | "gpt-5.2"
                 | "gpt-5.5"
+                | "gpt-5.6-sol"
+                | "gpt-5.6-terra"
+                | "gpt-5.6-luna"
                 | "gpt-5.4"
                 | "gpt-5.2-codex"
                 | "gpt-5.3-codex"
@@ -618,6 +621,18 @@ pub fn model_autocomplete_candidates() -> &'static [ModelAutocompleteCandidate] 
                 slug: "openai/gpt-5.4".to_string(),
                 description: Some("GPT-5.4".to_string()),
             });
+            for (id, name) in [
+                ("gpt-5.6-sol", "GPT-5.6 Sol"),
+                ("gpt-5.6-terra", "GPT-5.6 Terra"),
+                ("gpt-5.6-luna", "GPT-5.6 Luna"),
+            ] {
+                for provider in ["openai", "openai-codex"] {
+                    candidates.push(ModelAutocompleteCandidate {
+                        slug: format!("{provider}/{id}"),
+                        description: Some(name.to_string()),
+                    });
+                }
+            }
             candidates.push(ModelAutocompleteCandidate {
                 slug: "openai-codex/gpt-5.5".to_string(),
                 description: Some("GPT-5.5 Codex".to_string()),
@@ -1476,6 +1491,83 @@ fn built_in_models(auth: &AuthStorage, mode: ModelRegistryLoadMode) -> Vec<Model
             compat: None,
             oauth_config: None,
         });
+    }
+
+    // Keep the GPT-5.6 variants aligned with the current upstream catalog for
+    // direct OpenAI API-key and ChatGPT/Codex OAuth routing.
+    for (id, name, input, output, cache_read, cache_write) in [
+        ("gpt-5.6-sol", "GPT-5.6 Sol", 5.0, 30.0, 0.5, 6.25),
+        ("gpt-5.6-terra", "GPT-5.6 Terra", 2.5, 15.0, 0.25, 3.125),
+        ("gpt-5.6-luna", "GPT-5.6 Luna", 1.0, 6.0, 0.1, 1.25),
+    ] {
+        for provider in ["openai", "openai-codex"] {
+            if models
+                .iter()
+                .any(|entry| entry.model.provider == provider && entry.model.id == id)
+            {
+                continue;
+            }
+
+            let (api, base_url) = if provider == "openai" {
+                (
+                    if mode == ModelRegistryLoadMode::Full {
+                        Api::OpenAIResponses.to_string()
+                    } else {
+                        "openai-responses".to_string()
+                    },
+                    if mode == ModelRegistryLoadMode::Full {
+                        "https://api.openai.com/v1".to_string()
+                    } else {
+                        String::new()
+                    },
+                )
+            } else {
+                (
+                    if mode == ModelRegistryLoadMode::Full {
+                        Api::OpenAICodexResponses.to_string()
+                    } else {
+                        "openai-codex-responses".to_string()
+                    },
+                    if mode == ModelRegistryLoadMode::Full {
+                        "https://chatgpt.com/backend-api".to_string()
+                    } else {
+                        String::new()
+                    },
+                )
+            };
+
+            models.push(ModelEntry {
+                model: Model {
+                    id: id.to_string(),
+                    name: name.to_string(),
+                    api,
+                    provider: provider.to_string(),
+                    base_url,
+                    reasoning: true,
+                    input: vec![InputType::Text, InputType::Image],
+                    cost: ModelCost {
+                        input,
+                        output,
+                        cache_read,
+                        cache_write,
+                    },
+                    context_window: 272_000,
+                    max_tokens: 128_000,
+                    headers: HashMap::new(),
+                },
+                api_key: resolve_provider_api_key_cached(
+                    auth,
+                    provider,
+                    provider,
+                    &mut canonical_api_key_cache,
+                    &mut provider_api_key_cache,
+                ),
+                headers: HashMap::new(),
+                auth_header: true,
+                compat: None,
+                oauth_config: None,
+            });
+        }
     }
 
     // Ensure the latest Codex default exists for OpenAI Codex (ChatGPT) routing.
@@ -2614,6 +2706,109 @@ mod tests {
     }
 
     #[test]
+    fn gpt_5_6_variants_match_upstream_catalog() {
+        let (_dir, auth) = test_auth_storage();
+        let models = built_in_models(&auth, ModelRegistryLoadMode::Full);
+
+        for (provider, id, name, api, base_url, input, output, cache_read, cache_write) in [
+            (
+                "openai",
+                "gpt-5.6-sol",
+                "GPT-5.6 Sol",
+                "openai-responses",
+                "https://api.openai.com/v1",
+                5.0,
+                30.0,
+                0.5,
+                6.25,
+            ),
+            (
+                "openai",
+                "gpt-5.6-terra",
+                "GPT-5.6 Terra",
+                "openai-responses",
+                "https://api.openai.com/v1",
+                2.5,
+                15.0,
+                0.25,
+                3.125,
+            ),
+            (
+                "openai",
+                "gpt-5.6-luna",
+                "GPT-5.6 Luna",
+                "openai-responses",
+                "https://api.openai.com/v1",
+                1.0,
+                6.0,
+                0.1,
+                1.25,
+            ),
+            (
+                "openai-codex",
+                "gpt-5.6-sol",
+                "GPT-5.6 Sol",
+                "openai-codex-responses",
+                "https://chatgpt.com/backend-api",
+                5.0,
+                30.0,
+                0.5,
+                6.25,
+            ),
+            (
+                "openai-codex",
+                "gpt-5.6-terra",
+                "GPT-5.6 Terra",
+                "openai-codex-responses",
+                "https://chatgpt.com/backend-api",
+                2.5,
+                15.0,
+                0.25,
+                3.125,
+            ),
+            (
+                "openai-codex",
+                "gpt-5.6-luna",
+                "GPT-5.6 Luna",
+                "openai-codex-responses",
+                "https://chatgpt.com/backend-api",
+                1.0,
+                6.0,
+                0.1,
+                1.25,
+            ),
+        ] {
+            let entry = models
+                .iter()
+                .find(|entry| entry.model.provider == provider && entry.model.id == id)
+                .unwrap_or_else(|| panic!("missing {provider}/{id}"));
+            assert_eq!(entry.model.name, name);
+            assert_eq!(entry.model.api, api);
+            assert_eq!(entry.model.base_url, base_url);
+            assert!(entry.model.reasoning);
+            assert_eq!(entry.model.input, vec![InputType::Text, InputType::Image]);
+            assert_eq!(entry.model.context_window, 272_000);
+            assert_eq!(entry.model.max_tokens, 128_000);
+            assert_eq!(entry.model.cost.input, input);
+            assert_eq!(entry.model.cost.output, output);
+            assert_eq!(entry.model.cost.cache_read, cache_read);
+            assert_eq!(entry.model.cost.cache_write, cache_write);
+        }
+
+        let candidates = model_autocomplete_candidates();
+        for provider in ["openai", "openai-codex"] {
+            for id in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+                assert!(
+                    candidates
+                        .iter()
+                        .any(|candidate| candidate.slug == format!("{provider}/{id}")),
+                    "missing autocomplete candidate {provider}/{id}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn built_in_models_include_oauth_provider_entries() {
         let (_dir, auth) = test_auth_storage();
         let models = built_in_models(&auth, ModelRegistryLoadMode::Full);
@@ -3699,6 +3894,9 @@ mod tests {
         assert!(make_model_entry("gpt-5.1-codex-max", true).supports_xhigh());
         assert!(make_model_entry("gpt-5.2", true).supports_xhigh());
         assert!(make_model_entry("gpt-5.4", true).supports_xhigh());
+        assert!(make_model_entry("gpt-5.6-sol", true).supports_xhigh());
+        assert!(make_model_entry("gpt-5.6-terra", true).supports_xhigh());
+        assert!(make_model_entry("gpt-5.6-luna", true).supports_xhigh());
         assert!(make_model_entry("gpt-5.2-codex", true).supports_xhigh());
         assert!(make_model_entry("gpt-5.3-codex", true).supports_xhigh());
         assert!(make_model_entry("gpt-5.3-codex-spark", true).supports_xhigh());
@@ -5276,6 +5474,9 @@ mod tests {
                     "gpt-5.1-codex-max"
                         | "gpt-5.2"
                         | "gpt-5.4"
+                        | "gpt-5.6-sol"
+                        | "gpt-5.6-terra"
+                        | "gpt-5.6-luna"
                         | "gpt-5.2-codex"
                         | "gpt-5.3-codex"
                         | "gpt-5.3-codex-spark"

--- a/tests/suite_classification.toml
+++ b/tests/suite_classification.toml
@@ -311,6 +311,7 @@ files = [
     "e2e_swarm_flight_recorder",
     "e2e_tools",
     "e2e_ts_extension_loading",
+    "e2e_transient_retry_resume",
     "e2e_tui",
     "e2e_tui_features",
     "e2e_tui_perf",


### PR DESCRIPTION
I just had 5.6 make a version for me which supports 5.6 models and make sure that the linux version builds, you probably want to make some changes before/if merging but hopefully this saves you some time/inference or is useful to others wanting 5.6 support immediately.