### PR TITLE
perf: resolve installed npm packages without startup network I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,6 +3893,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3971,6 +3993,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "node-semver"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b1a233ea5dc37d2cfba31cfc87a5a56cc2a9c04e3672c15d179ca118dae40a7"
+dependencies = [
+ "bytecount",
+ "miette",
+ "nom 7.1.3",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4499,6 +4534,7 @@ dependencies = [
  "loom",
  "md-5",
  "memchr",
+ "node-semver",
  "pbkdf2",
  "pretty_assertions",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "capacity_builder"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f2d24a6dcf0cd402a21b65d35340f3a49ff3475dc5fdac91d22d2733e6641c6"
+dependencies = [
+ "capacity_builder_macros",
+ "ecow",
+ "hipstr",
+ "itoa",
+]
+
+[[package]]
+name = "capacity_builder_macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b4a6cae9efc04cc6cbb8faf338d2c497c165c83e74509cf4dbedea948bbf6e5"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1556,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_error"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3007d3f1ea92ea503324ae15883aac0c2de2b8cf6fead62203ff6a67161007ab"
+dependencies = [
+ "deno_error_macro",
+ "libc",
+]
+
+[[package]]
+name = "deno_error_macro"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b565e60a9685cdf312c888665b5f8647ac692a7da7e058a5e2268a466da8eaf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deno_semver"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff487e9bf55c39bfbc47418a009a0de0988c4fea5e48e8ca787fa7dbff8056cc"
+dependencies = [
+ "capacity_builder",
+ "deno_error",
+ "ecow",
+ "hipstr",
+ "monch",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,6 +1805,15 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ecow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ed25519"
@@ -3176,6 +3245,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hipstr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97971ffc85d4c98de12e2608e992a43f5294ebb625fdb045b27c731b64c4c6d6"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "sptr",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3893,28 +3973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miette"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
-dependencies = [
- "cfg-if",
- "miette-derive",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "miette-derive"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3941,6 +3999,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "monch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bcc6ad3b93f756f2532d29f7c7291b8d246a2c460a99a3611327bb726830014"
 
 [[package]]
 name = "moxcms"
@@ -3993,19 +4057,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "node-semver"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1a233ea5dc37d2cfba31cfc87a5a56cc2a9c04e3672c15d179ca118dae40a7"
-dependencies = [
- "bytecount",
- "miette",
- "nom 7.1.3",
- "serde",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4517,6 +4568,7 @@ dependencies = [
  "crossbeam-queue",
  "crossterm",
  "ctrlc",
+ "deno_semver",
  "dirs",
  "enable-ansi-support",
  "filetime",
@@ -4534,7 +4586,6 @@ dependencies = [
  "loom",
  "md-5",
  "memchr",
- "node-semver",
  "pbkdf2",
  "pretty_assertions",
  "proptest",
@@ -5580,6 +5631,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5876,6 +5937,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "sqlmodel-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,7 +230,7 @@ getrandom = "0.4.1"
 regex = "1.12.3"
 ring = "0.17.14"
 semver = "1.0.27"
-node-semver = "2.2.0"
+deno_semver = "0.10.1"
 crc32c = "0.6"
 ast-grep-core = "0.40"
 ast-grep-language = { version = "0.40", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,6 +230,7 @@ getrandom = "0.4.1"
 regex = "1.12.3"
 ring = "0.17.14"
 semver = "1.0.27"
+node-semver = "2.2.0"
 crc32c = "0.6"
 ast-grep-core = "0.40"
 ast-grep-language = { version = "0.40", default-features = false, features = [

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -422,7 +422,7 @@ impl PackageManager {
         let source = validate_non_empty_source(source, "Package source")?;
         let parsed = parse_source(source, &self.cwd);
         Ok(match parsed {
-            ParsedSource::Npm { name, .. } => self.npm_install_path(&name, scope)?,
+            ParsedSource::Npm { name, .. } => Some(self.npm_install_path(&name, scope)?),
             ParsedSource::Git { host, path, .. } => {
                 Some(self.checked_git_install_path(&host, &path, scope)?)
             }
@@ -538,9 +538,7 @@ impl PackageManager {
                         global_npm_root.as_deref(),
                     ) {
                         Some(path) => path,
-                        None => self
-                            .npm_install_path(&name, entry.scope)?
-                            .unwrap_or_else(|| self.cwd.join("node_modules").join(&name)),
+                        None => self.npm_install_path(&name, entry.scope)?,
                     };
 
                     if !installed_path.exists() {
@@ -1178,12 +1176,7 @@ impl PackageManager {
         let parsed = parse_source(source, &self.cwd);
         match parsed {
             ParsedSource::Npm { spec, name, pinned } => {
-                let installed_path = self.npm_install_path(&name, scope)?.ok_or_else(|| {
-                    Error::tool(
-                        "package_manager",
-                        "npm lock verification requires a concrete install path",
-                    )
-                })?;
+                let installed_path = self.npm_install_path(&name, scope)?;
                 if !installed_path.exists() {
                     return Err(Error::tool(
                         "package_manager",
@@ -1410,11 +1403,11 @@ impl PackageManager {
             .or_else(|| global_npm_root.map(|root| root.join(name)))
     }
 
-    fn npm_install_path(&self, name: &str, scope: PackageScope) -> Result<Option<PathBuf>> {
+    fn npm_install_path(&self, name: &str, scope: PackageScope) -> Result<PathBuf> {
         if let Some(path) = self.npm_install_path_with_root(name, scope, None) {
-            return Ok(Some(path));
+            return Ok(path);
         }
-        Ok(Some(Self::global_npm_root()?.join(name)))
+        Ok(Self::global_npm_root()?.join(name))
     }
 
     fn git_root(&self, scope: PackageScope) -> Option<PathBuf> {
@@ -1468,17 +1461,15 @@ impl PackageManager {
             run_command("npm", ["install", "-g", spec], None)?;
         }
 
-        // Basic sanity: installed path exists
-        if let Some(installed) = self.npm_install_path(&name, scope)? {
-            if !installed.exists() {
-                return Err(Error::tool(
-                    "npm",
-                    format!(
-                        "npm install succeeded but '{}' is missing",
-                        installed.display()
-                    ),
-                ));
-            }
+        let installed = self.npm_install_path(&name, scope)?;
+        if !installed.exists() {
+            return Err(Error::tool(
+                "npm",
+                format!(
+                    "npm install succeeded but '{}' is missing",
+                    installed.display()
+                ),
+            ));
         }
 
         Ok(())
@@ -6137,6 +6128,7 @@ mod tests {
         for (source, expected_name, expected_pinned) in [
             ("npm:@scope/pkg@1.0.0", "@scope/pkg", true),
             ("npm:@scope/pkg@v1.0.0", "@scope/pkg", true),
+            ("npm:@scope/pkg@1.0", "@scope/pkg", false),
             ("npm:express", "express", false),
             ("npm:express@latest", "express", false),
             ("npm:express@^4.0.0", "express", false),

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -531,7 +531,7 @@ impl PackageManager {
                         entry.scope == PackageScope::Temporary,
                     )?;
                 }
-                ParsedSource::Npm { name, .. } => {
+                ParsedSource::Npm { spec, name, .. } => {
                     let installed_path = match self.npm_install_path_with_root(
                         &name,
                         entry.scope,
@@ -541,7 +541,7 @@ impl PackageManager {
                         None => self.npm_install_path(&name, entry.scope)?,
                     };
 
-                    if !installed_path.exists() {
+                    if npm_spec_needs_install(&spec, &installed_path) {
                         return Ok(None);
                     }
 
@@ -3903,8 +3903,17 @@ fn is_exact_npm_version(value: &str) -> bool {
 }
 
 fn parse_exact_npm_version(value: &str) -> Option<NpmVersion> {
-    let normalized = value.strip_prefix('v').unwrap_or(value);
-    StrictVersion::parse(normalized).ok()?;
+    const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
+    let normalized = value.trim();
+    let normalized = normalized.strip_prefix('v').unwrap_or(normalized);
+    let strict = StrictVersion::parse(normalized).ok()?;
+    if [strict.major, strict.minor, strict.patch]
+        .into_iter()
+        .any(|component| component > MAX_SAFE_INTEGER)
+    {
+        return None;
+    }
     NpmVersion::parse_from_npm(normalized).ok()
 }
 
@@ -5628,6 +5637,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn blocking_resolution_defers_incompatible_npm_versions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project_root = dir.path().join("project");
+        let project_base = project_root.join(".pi");
+        let project_settings = project_base.join("settings.json");
+        let installed = project_base.join("npm/node_modules/demo");
+        fs::create_dir_all(&installed).expect("create installed package");
+        fs::write(&project_settings, br#"{"packages":["npm:demo@^2.0.0"]}"#)
+            .expect("write project settings");
+        fs::write(
+            installed.join("package.json"),
+            br#"{"name":"demo","version":"1.0.0"}"#,
+        )
+        .expect("write package metadata");
+
+        let roots = ResolveRoots {
+            global_settings_path: dir.path().join("global-settings.json"),
+            project_settings_path: project_settings,
+            global_base_dir: dir.path().join("global"),
+            project_base_dir: project_base,
+            project_settings_enabled: true,
+        };
+        let manager = PackageManager::new(project_root);
+
+        assert!(
+            manager
+                .resolve_package_resources_with_roots_blocking(&roots)
+                .expect("resolve package resources")
+                .is_none(),
+            "the fast path must defer installation to canonical async resolution"
+        );
+    }
+
     // ======================================================================
     // ResourceList dedup
     // ======================================================================
@@ -6128,6 +6171,9 @@ mod tests {
         for (source, expected_name, expected_pinned) in [
             ("npm:@scope/pkg@1.0.0", "@scope/pkg", true),
             ("npm:@scope/pkg@v1.0.0", "@scope/pkg", true),
+            ("npm:@scope/pkg@ 1.0.0 ", "@scope/pkg", true),
+            ("npm:@scope/pkg@9007199254740991.0.0", "@scope/pkg", true),
+            ("npm:@scope/pkg@9007199254740992.0.0", "@scope/pkg", false),
             ("npm:@scope/pkg@1.0", "@scope/pkg", false),
             ("npm:express", "express", false),
             ("npm:express@latest", "express", false),

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -12,7 +12,7 @@ use crate::error::{Error, Result};
 use crate::extension_index::ExtensionIndexStore;
 use crate::extensions::{CompatibilityScanner, load_extension_manifest};
 use asupersync::channel::oneshot;
-use node_semver::{Range as NpmVersionRange, Version as NpmVersion};
+use deno_semver::{Version as NpmVersion, VersionReq as NpmVersionReq};
 use semver::Version as StrictVersion;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -23,7 +23,6 @@ use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::{Arc, Mutex, PoisonError};
 use std::thread;
 use tracing::{info, warn};
 
@@ -130,7 +129,6 @@ impl ResolveRoots {
 #[derive(Debug, Clone)]
 pub struct PackageManager {
     cwd: PathBuf,
-    global_npm_root: Arc<Mutex<Option<PathBuf>>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -237,11 +235,8 @@ pub const PACKAGE_LOCK_SCHEMA: &str = "pi.package_lock.v1";
 pub const PACKAGE_TRUST_AUDIT_SCHEMA: &str = "pi.package_trust_audit.v1";
 
 impl PackageManager {
-    pub fn new(cwd: PathBuf) -> Self {
-        Self {
-            cwd,
-            global_npm_root: Arc::new(Mutex::new(None)),
-        }
+    pub const fn new(cwd: PathBuf) -> Self {
+        Self { cwd }
     }
 
     /// Resolve a shorthand source (`id`/`name`) via the local extension index when possible.
@@ -508,6 +503,7 @@ impl PackageManager {
             scope: PackageScope::Project,
         }));
         let package_sources = self.dedupe_packages(all_packages);
+        let global_npm_root = self.global_npm_root_for_sources(&package_sources)?;
 
         let mut accumulator = ResourceAccumulator::new();
 
@@ -536,9 +532,16 @@ impl PackageManager {
                     )?;
                 }
                 ParsedSource::Npm { name, .. } => {
-                    let installed_path = self
-                        .npm_install_path(&name, entry.scope)?
-                        .unwrap_or_else(|| self.cwd.join("node_modules").join(&name));
+                    let installed_path = match self.npm_install_path_with_root(
+                        &name,
+                        entry.scope,
+                        global_npm_root.as_deref(),
+                    ) {
+                        Some(path) => path,
+                        None => self
+                            .npm_install_path(&name, entry.scope)?
+                            .unwrap_or_else(|| self.cwd.join("node_modules").join(&name)),
+                    };
 
                     if !installed_path.exists() {
                         return Ok(None);
@@ -663,7 +666,12 @@ impl PackageManager {
 
         // Offload the heavy lifting (sync I/O) to a thread
         let handle = thread::spawn(move || {
-            let res: Result<(SettingsSnapshot, SettingsSnapshot, Vec<ScopedPackage>)> = (|| {
+            let res: Result<(
+                SettingsSnapshot,
+                SettingsSnapshot,
+                Vec<ScopedPackage>,
+                Option<PathBuf>,
+            )> = (|| {
                 let global = read_settings_snapshot(&roots_for_setup.global_settings_path)?;
                 let project = read_project_settings_snapshot(&roots_for_setup)?;
 
@@ -682,22 +690,28 @@ impl PackageManager {
                     }));
                 }
                 let package_sources = this_for_setup.dedupe_packages(all_packages);
-                Ok((global, project, package_sources))
-            })(
-            );
+                let global_npm_root =
+                    this_for_setup.global_npm_root_for_sources(&package_sources)?;
+                Ok((global, project, package_sources, global_npm_root))
+            })();
             let cx = AgentCx::for_request();
             let _ = tx.send(cx.cx(), res);
         });
 
         let cx = AgentCx::for_request();
         let recv_result = rx.recv(cx.cx()).await;
-        let (global, project, package_sources) =
+        let (global, project, package_sources, global_npm_root) =
             finish_package_task(handle, recv_result, "Resolve setup task cancelled")?;
 
         let mut accumulator = ResourceAccumulator::new();
 
         // Missing or incompatible packages may require async installation.
-        Box::pin(self.resolve_package_sources(&package_sources, &mut accumulator)).await?;
+        Box::pin(self.resolve_package_sources(
+            &package_sources,
+            global_npm_root.as_deref(),
+            &mut accumulator,
+        ))
+        .await?;
 
         // Offload the rest of sync resolution
         let this = self.clone();
@@ -794,7 +808,7 @@ impl PackageManager {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        Box::pin(self.resolve_package_sources(&package_sources, &mut accumulator)).await?;
+        Box::pin(self.resolve_package_sources(&package_sources, None, &mut accumulator)).await?;
 
         let (tx, mut rx) = oneshot::channel();
         let accumulator = std::sync::Mutex::new(accumulator);
@@ -1196,9 +1210,10 @@ impl PackageManager {
                     .as_deref()
                     .and_then(parse_exact_npm_version)
                 {
-                    if parse_exact_npm_version(&installed_version)
-                        .is_none_or(|installed| installed != expected)
-                    {
+                    // npm version precedence intentionally ignores build metadata.
+                    let installed_matches = parse_exact_npm_version(&installed_version)
+                        .is_some_and(|installed| installed.cmp(&expected).is_eq());
+                    if !installed_matches {
                         return Err(verification_error(
                             "npm_version_mismatch",
                             &format!(
@@ -1328,15 +1343,7 @@ impl PackageManager {
         Config::global_dir().join("git")
     }
 
-    fn global_npm_root(&self) -> Result<PathBuf> {
-        let mut cached = self
-            .global_npm_root
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
-        if let Some(root) = cached.as_ref() {
-            return Ok(root.clone());
-        }
-
+    fn global_npm_root() -> Result<PathBuf> {
         let output = Command::new("npm")
             .args(["root", "-g"])
             .stdin(Stdio::null())
@@ -1366,10 +1373,21 @@ impl PackageManager {
             return Err(Error::tool("npm", "npm root -g returned empty output"));
         }
 
-        let root = PathBuf::from(root);
-        *cached = Some(root.clone());
-        drop(cached);
-        Ok(root)
+        Ok(PathBuf::from(root))
+    }
+
+    fn global_npm_root_for_sources(&self, sources: &[ScopedPackage]) -> Result<Option<PathBuf>> {
+        sources
+            .iter()
+            .any(|entry| {
+                entry.scope == PackageScope::User
+                    && matches!(
+                        parse_source(entry.pkg.source.trim(), &self.cwd),
+                        ParsedSource::Npm { .. }
+                    )
+            })
+            .then(Self::global_npm_root)
+            .transpose()
     }
 
     fn npm_prefix_root(&self, scope: PackageScope) -> Option<PathBuf> {
@@ -1380,11 +1398,23 @@ impl PackageManager {
         }
     }
 
+    fn npm_install_path_with_root(
+        &self,
+        name: &str,
+        scope: PackageScope,
+        global_npm_root: Option<&Path>,
+    ) -> Option<PathBuf> {
+        self.npm_prefix_root(scope)
+            .map(|prefix_root| prefix_root.join("node_modules").join(name))
+            // ubs:ignore configured npm package key; scoped names intentionally contain a slash.
+            .or_else(|| global_npm_root.map(|root| root.join(name)))
+    }
+
     fn npm_install_path(&self, name: &str, scope: PackageScope) -> Result<Option<PathBuf>> {
-        Ok(Some(match self.npm_prefix_root(scope) {
-            Some(prefix_root) => prefix_root.join("node_modules").join(name),
-            None => self.global_npm_root()?.join(name),
-        }))
+        if let Some(path) = self.npm_install_path_with_root(name, scope, None) {
+            return Ok(Some(path));
+        }
+        Ok(Some(Self::global_npm_root()?.join(name)))
     }
 
     fn git_root(&self, scope: PackageScope) -> Option<PathBuf> {
@@ -1817,6 +1847,7 @@ impl PackageManager {
     async fn resolve_package_sources(
         &self,
         sources: &[ScopedPackage],
+        global_npm_root: Option<&Path>,
         accumulator: &mut ResourceAccumulator,
     ) -> Result<()> {
         for entry in sources {
@@ -1844,11 +1875,17 @@ impl PackageManager {
                     )?;
                 }
                 ParsedSource::Npm { spec, name, .. } => {
-                    // Offload installed_path check
-                    let installed_path = self
-                        .installed_path(&format!("npm:{name}"), entry.scope)
-                        .await?
-                        .unwrap_or_else(|| self.cwd.join("node_modules").join(&name));
+                    let installed_path = match self.npm_install_path_with_root(
+                        &name,
+                        entry.scope,
+                        global_npm_root,
+                    ) {
+                        Some(path) => path,
+                        None => self
+                            .installed_path(&format!("npm:{name}"), entry.scope)
+                            .await?
+                            .unwrap_or_else(|| self.cwd.join("node_modules").join(&name)),
+                    };
 
                     // Installed packages are startup state, not an update check.
                     // Remote freshness belongs to the explicit `pi update` path;
@@ -3586,17 +3623,17 @@ fn npm_spec_needs_install(spec: &str, installed_path: &Path) -> bool {
         return false;
     }
 
-    if let Some(requested) = parse_exact_npm_version(requested_version) {
-        return !NpmVersion::parse(&installed_version)
-            .is_ok_and(|installed| installed == requested);
-    }
-
-    let Ok(requirement) = NpmVersionRange::parse(requested_version) else {
-        // Dist-tags are intentionally floating. `pi update` resolves them
-        // against npm.
+    let Ok(requirement) = NpmVersionReq::parse_from_npm(requested_version) else {
+        // Unknown npm spec forms remain floating. `pi update` resolves them
+        // through npm.
         return false;
     };
-    !NpmVersion::parse(&installed_version).is_ok_and(|installed| requirement.satisfies(&installed))
+    if requirement.tag().is_some() {
+        // Dist-tags are intentionally floating.
+        return false;
+    }
+    !parse_exact_npm_version(&installed_version)
+        .is_some_and(|installed| requirement.matches(&installed))
 }
 
 fn is_local_npm_reference(reference: &str) -> bool {
@@ -3877,7 +3914,7 @@ fn is_exact_npm_version(value: &str) -> bool {
 fn parse_exact_npm_version(value: &str) -> Option<NpmVersion> {
     let normalized = value.strip_prefix('v').unwrap_or(value);
     StrictVersion::parse(normalized).ok()?;
-    NpmVersion::parse(normalized).ok()
+    NpmVersion::parse_from_npm(normalized).ok()
 }
 
 pub fn digest_package_path(path: &Path) -> Result<String> {
@@ -5542,20 +5579,22 @@ mod tests {
             ("demo@1.2.3", "1.2.3", false),
             ("demo@1.2.4", "1.2.3", true),
             ("demo@v1.2.3", "1.2.3", false),
-            ("demo@=1.2.3", "1.2.3", false),
-            ("demo@=1.2.4", "1.2.3", true),
             ("demo@^1.2.0", "1.9.0", false),
             ("demo@^2.0.0", "1.9.0", true),
             ("demo@~1.2.0", "1.2.9", false),
             ("demo@1.2", "1.2.9", false),
             ("demo@1.2", "1.9.0", true),
             ("demo@1.x", "1.9.0", false),
-            ("demo@1.x", "2.0.0", true),
             ("demo@1.2.3 || >=2.0.0", "2.1.0", false),
-            ("demo@1.2.3 || >=2.0.0", "1.9.0", true),
             ("demo@1.2.0 - 1.4.0", "1.3.0", false),
+            ("demo@^1.2.0", "not-semver", true),
+            ("demo@^1.2.0", "01.2.3", true),
+            ("demo@^1.2.0", "1.2.3alpha", true),
+            ("demo@^1.2.0", "v 1.2.3", true),
+            ("demo@>=2.0.0 <1.0.0", "0.5.0", true),
+            ("demo@>=2.0.0 <1.0.0", "1.5.0", true),
+            ("demo@>=2.0.0 <1.0.0", "2.5.0", true),
             ("demo@latest", "1.2.3", false),
-            ("demo@beta", "1.2.3", false),
             ("demo@file:../demo", "1.2.3", false),
         ] {
             fs::write(
@@ -6093,35 +6132,26 @@ mod tests {
     // ======================================================================
 
     #[test]
-    fn parse_source_npm_prefix() -> std::result::Result<(), String> {
+    fn parse_source_recognizes_only_exact_npm_versions_as_pinned() {
         let dir = tempfile::tempdir().expect("tempdir");
-        for source in ["npm:@scope/pkg@1.0.0", "npm:@scope/pkg@v1.0.0"] {
-            let ParsedSource::Npm { name, pinned, .. } = parse_source(source, dir.path()) else {
-                return Err(format!("unexpected parsed source for {source}"));
-            };
-            assert_eq!(name, "@scope/pkg");
-            assert!(pinned, "{source} should be pinned");
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn parse_source_npm_unpinned() -> std::result::Result<(), String> {
-        let dir = tempfile::tempdir().expect("tempdir");
-        for source in [
-            "npm:express",
-            "npm:express@latest",
-            "npm:express@^4.0.0",
-            "npm:express@~4.0.0",
-            "npm:express@=4.0.0",
-            "npm:express@file:../express",
+        for (source, expected_name, expected_pinned) in [
+            ("npm:@scope/pkg@1.0.0", "@scope/pkg", true),
+            ("npm:@scope/pkg@v1.0.0", "@scope/pkg", true),
+            ("npm:express", "express", false),
+            ("npm:express@latest", "express", false),
+            ("npm:express@^4.0.0", "express", false),
+            ("npm:express@=4.0.0", "express", false),
+            ("npm:express@file:../express", "express", false),
         ] {
-            let ParsedSource::Npm { pinned, .. } = parse_source(source, dir.path()) else {
-                return Err(format!("unexpected parsed source for {source}"));
+            let ParsedSource::Npm { name, pinned, .. } = parse_source(source, dir.path()) else {
+                panic!("unexpected parsed source for {source}"); // ubs:ignore test assertion.
             };
-            assert!(!pinned, "{source} should remain updateable");
+            assert_eq!(name, expected_name);
+            assert_eq!(
+                pinned, expected_pinned,
+                "unexpected pinned state for {source}"
+            );
         }
-        Ok(())
     }
 
     #[test]
@@ -7256,13 +7286,9 @@ mod tests {
 
         let manager = PackageManager::new(cwd);
         for (source, expected_pinned) in [
-            ("npm:demo-pkg@1.2.3", true),
             ("npm:demo-pkg@v1.2.3", true),
-            ("npm:demo-pkg@=1.2.3", false),
-            ("npm:demo-pkg@1.2", false),
+            ("npm:demo-pkg@1.2.3+build", true),
             ("npm:demo-pkg@latest", false),
-            ("npm:demo-pkg@beta", false),
-            ("npm:demo-pkg@file:../demo-pkg", false),
         ] {
             let entry = manager
                 .build_lock_entry(source, PackageScope::Project)

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -12,6 +12,8 @@ use crate::error::{Error, Result};
 use crate::extension_index::ExtensionIndexStore;
 use crate::extensions::{CompatibilityScanner, load_extension_manifest};
 use asupersync::channel::oneshot;
+use node_semver::{Range as NpmVersionRange, Version as NpmVersion};
+use semver::Version as StrictVersion;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -21,6 +23,7 @@ use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex, PoisonError};
 use std::thread;
 use tracing::{info, warn};
 
@@ -127,6 +130,7 @@ impl ResolveRoots {
 #[derive(Debug, Clone)]
 pub struct PackageManager {
     cwd: PathBuf,
+    global_npm_root: Arc<Mutex<Option<PathBuf>>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -233,8 +237,11 @@ pub const PACKAGE_LOCK_SCHEMA: &str = "pi.package_lock.v1";
 pub const PACKAGE_TRUST_AUDIT_SCHEMA: &str = "pi.package_trust_audit.v1";
 
 impl PackageManager {
-    pub const fn new(cwd: PathBuf) -> Self {
-        Self { cwd }
+    pub fn new(cwd: PathBuf) -> Self {
+        Self {
+            cwd,
+            global_npm_root: Arc::new(Mutex::new(None)),
+        }
     }
 
     /// Resolve a shorthand source (`id`/`name`) via the local extension index when possible.
@@ -689,7 +696,7 @@ impl PackageManager {
 
         let mut accumulator = ResourceAccumulator::new();
 
-        // This part is async (network calls for NPM)
+        // Missing or incompatible packages may require async installation.
         Box::pin(self.resolve_package_sources(&package_sources, &mut accumulator)).await?;
 
         // Offload the rest of sync resolution
@@ -1187,9 +1194,11 @@ impl PackageManager {
 
                 if let Some(expected) = requested_version
                     .as_deref()
-                    .filter(|value| is_exact_npm_version(value))
+                    .and_then(parse_exact_npm_version)
                 {
-                    if expected != installed_version {
+                    if parse_exact_npm_version(&installed_version)
+                        .is_none_or(|installed| installed != expected)
+                    {
                         return Err(verification_error(
                             "npm_version_mismatch",
                             &format!(
@@ -1319,8 +1328,15 @@ impl PackageManager {
         Config::global_dir().join("git")
     }
 
-    #[allow(clippy::unused_self)]
     fn global_npm_root(&self) -> Result<PathBuf> {
+        let mut cached = self
+            .global_npm_root
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if let Some(root) = cached.as_ref() {
+            return Ok(root.clone());
+        }
+
         let output = Command::new("npm")
             .args(["root", "-g"])
             .stdin(Stdio::null())
@@ -1350,7 +1366,10 @@ impl PackageManager {
             return Err(Error::tool("npm", "npm root -g returned empty output"));
         }
 
-        Ok(PathBuf::from(root))
+        let root = PathBuf::from(root);
+        *cached = Some(root.clone());
+        drop(cached);
+        Ok(root)
     }
 
     fn npm_prefix_root(&self, scope: PackageScope) -> Option<PathBuf> {
@@ -1824,15 +1843,18 @@ impl PackageManager {
                         entry.scope == PackageScope::Temporary,
                     )?;
                 }
-                ParsedSource::Npm { spec, name, pinned } => {
+                ParsedSource::Npm { spec, name, .. } => {
                     // Offload installed_path check
                     let installed_path = self
                         .installed_path(&format!("npm:{name}"), entry.scope)
                         .await?
                         .unwrap_or_else(|| self.cwd.join("node_modules").join(&name));
 
-                    let needs_install = !installed_path.exists()
-                        || Box::pin(self.npm_needs_update(&spec, pinned, &installed_path)).await;
+                    // Installed packages are startup state, not an update check.
+                    // Remote freshness belongs to the explicit `pi update` path;
+                    // putting it here makes every launch depend on registry latency.
+                    let needs_install =
+                        !installed_path.exists() || npm_spec_needs_install(&spec, &installed_path);
                     if needs_install {
                         self.install(source_str, entry.scope).await?;
                     }
@@ -1871,24 +1893,6 @@ impl PackageManager {
         }
 
         Ok(())
-    }
-
-    async fn npm_needs_update(&self, spec: &str, pinned: bool, installed_path: &Path) -> bool {
-        let installed_version = read_installed_npm_version(installed_path);
-        let Some(installed_version) = installed_version else {
-            return true;
-        };
-
-        let (_, pinned_version) = parse_npm_spec(spec);
-        if pinned {
-            return pinned_version
-                .as_deref()
-                .is_some_and(|pv| pinned_npm_version_needs_update(pv, &installed_version));
-        }
-
-        Box::pin(get_latest_npm_version(installed_path, spec))
-            .await
-            .is_ok_and(|latest| latest != installed_version)
     }
 
     fn resolve_local_extension_source(
@@ -3123,54 +3127,8 @@ fn read_installed_npm_version(installed_path: &Path) -> Option<String> {
     let json: Value = serde_json::from_str(&raw).ok()?;
     json.get("version")
         .and_then(Value::as_str)
+        .filter(|version| !version.is_empty())
         .map(str::to_string)
-}
-
-async fn get_latest_npm_version(installed_path: &Path, spec: &str) -> Result<String> {
-    let (name, _) = parse_npm_spec(spec);
-    let url = format!("https://registry.npmjs.org/{name}/latest");
-    let client = crate::http::client::Client::new();
-    let response = Box::pin(client.get(&url).send()).await.map_err(|e| {
-        Error::tool(
-            "npm",
-            format!(
-                "Failed to fetch npm registry for {}: {e}",
-                installed_path.display()
-            ),
-        )
-    })?;
-
-    let status = response.status();
-    let body = response.text().await.map_err(|e| {
-        Error::tool(
-            "npm",
-            format!(
-                "Failed to read npm registry response for {}: {e}",
-                installed_path.display()
-            ),
-        )
-    })?;
-
-    if !(200..300).contains(&status) {
-        return Err(Error::tool(
-            "npm",
-            format!("npm registry error (HTTP {status}): {body}"),
-        ));
-    }
-
-    let data: Value = serde_json::from_str(&body).map_err(|e| {
-        Error::tool(
-            "npm",
-            format!(
-                "Failed to parse npm registry response for {}: {e}",
-                installed_path.display()
-            ),
-        )
-    })?;
-    data.get("version")
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .ok_or_else(|| Error::tool("npm", "Registry response missing version"))
 }
 
 #[derive(Debug, Clone)]
@@ -3201,7 +3159,7 @@ fn parse_source(source: &str, cwd: &Path) -> ParsedSource {
         return ParsedSource::Npm {
             spec,
             name,
-            pinned: version.is_some(),
+            pinned: version.as_deref().is_some_and(is_exact_npm_version),
         };
     }
 
@@ -3616,8 +3574,29 @@ fn parse_npm_spec(spec: &str) -> (String, Option<String>) {
     }
 }
 
-fn pinned_npm_version_needs_update(requested_version: &str, installed_version: &str) -> bool {
-    !is_local_npm_reference(requested_version) && requested_version != installed_version
+fn npm_spec_needs_install(spec: &str, installed_path: &Path) -> bool {
+    let Some(installed_version) = read_installed_npm_version(installed_path) else {
+        return true;
+    };
+    let (_, requested_version) = parse_npm_spec(spec);
+    let Some(requested_version) = requested_version.as_deref() else {
+        return false;
+    };
+    if is_local_npm_reference(requested_version) {
+        return false;
+    }
+
+    if let Some(requested) = parse_exact_npm_version(requested_version) {
+        return !NpmVersion::parse(&installed_version)
+            .is_ok_and(|installed| installed == requested);
+    }
+
+    let Ok(requirement) = NpmVersionRange::parse(requested_version) else {
+        // Dist-tags are intentionally floating. `pi update` resolves them
+        // against npm.
+        return false;
+    };
+    !NpmVersion::parse(&installed_version).is_ok_and(|installed| requirement.satisfies(&installed))
 }
 
 fn is_local_npm_reference(reference: &str) -> bool {
@@ -3892,13 +3871,13 @@ pub fn write_package_lockfile_atomic(path: &Path, lockfile: &PackageLockfile) ->
 }
 
 fn is_exact_npm_version(value: &str) -> bool {
-    !value.is_empty()
-        && !value.contains(|ch: char| {
-            matches!(
-                ch,
-                '^' | '~' | '>' | '<' | '=' | '*' | 'x' | 'X' | '|' | ' ' | '\t'
-            )
-        })
+    parse_exact_npm_version(value).is_some()
+}
+
+fn parse_exact_npm_version(value: &str) -> Option<NpmVersion> {
+    let normalized = value.strip_prefix('v').unwrap_or(value);
+    StrictVersion::parse(normalized).ok()?;
+    NpmVersion::parse(normalized).ok()
 }
 
 pub fn digest_package_path(path: &Path) -> Result<String> {
@@ -5552,6 +5531,73 @@ mod tests {
         assert!(version.is_none());
     }
 
+    #[test]
+    fn npm_spec_install_decision_uses_local_semver_constraints() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let installed = dir.path().join("demo");
+        fs::create_dir_all(&installed).expect("create installed package");
+
+        for (spec, installed_version, expected) in [
+            ("demo", "1.2.3", false),
+            ("demo@1.2.3", "1.2.3", false),
+            ("demo@1.2.4", "1.2.3", true),
+            ("demo@v1.2.3", "1.2.3", false),
+            ("demo@=1.2.3", "1.2.3", false),
+            ("demo@=1.2.4", "1.2.3", true),
+            ("demo@^1.2.0", "1.9.0", false),
+            ("demo@^2.0.0", "1.9.0", true),
+            ("demo@~1.2.0", "1.2.9", false),
+            ("demo@1.2", "1.2.9", false),
+            ("demo@1.2", "1.9.0", true),
+            ("demo@1.x", "1.9.0", false),
+            ("demo@1.x", "2.0.0", true),
+            ("demo@1.2.3 || >=2.0.0", "2.1.0", false),
+            ("demo@1.2.3 || >=2.0.0", "1.9.0", true),
+            ("demo@1.2.0 - 1.4.0", "1.3.0", false),
+            ("demo@latest", "1.2.3", false),
+            ("demo@beta", "1.2.3", false),
+            ("demo@file:../demo", "1.2.3", false),
+        ] {
+            fs::write(
+                installed.join("package.json"),
+                serde_json::to_vec(&json!({
+                    "name": "demo",
+                    "version": installed_version,
+                }))
+                .expect("serialize package"),
+            )
+            .expect("write package");
+            assert_eq!(
+                npm_spec_needs_install(spec, &installed),
+                expected,
+                "unexpected install decision for {spec} at {installed_version}"
+            );
+        }
+
+        let missing = dir.path().join("missing");
+        assert!(
+            npm_spec_needs_install("demo", &missing),
+            "missing package metadata must trigger installation"
+        );
+
+        fs::write(installed.join("package.json"), b"{ not json")
+            .expect("write malformed package metadata");
+        assert!(
+            npm_spec_needs_install("demo", &installed),
+            "malformed package metadata must trigger installation"
+        );
+
+        fs::write(
+            installed.join("package.json"),
+            br#"{"name":"demo","version":""}"#,
+        )
+        .expect("write empty package version");
+        assert!(
+            npm_spec_needs_install("demo", &installed),
+            "an empty package version must trigger installation"
+        );
+    }
+
     // ======================================================================
     // ResourceList dedup
     // ======================================================================
@@ -6047,27 +6093,35 @@ mod tests {
     // ======================================================================
 
     #[test]
-    fn parse_source_npm_prefix() {
+    fn parse_source_npm_prefix() -> std::result::Result<(), String> {
         let dir = tempfile::tempdir().expect("tempdir");
-        match parse_source("npm:@scope/pkg@1.0", dir.path()) {
-            ParsedSource::Npm { spec, name, pinned } => {
-                assert_eq!(spec, "@scope/pkg@1.0");
-                assert_eq!(name, "@scope/pkg");
-                assert!(pinned);
-            }
-            other => panic!("Unexpected parsed source: {:?}", other),
+        for source in ["npm:@scope/pkg@1.0.0", "npm:@scope/pkg@v1.0.0"] {
+            let ParsedSource::Npm { name, pinned, .. } = parse_source(source, dir.path()) else {
+                return Err(format!("unexpected parsed source for {source}"));
+            };
+            assert_eq!(name, "@scope/pkg");
+            assert!(pinned, "{source} should be pinned");
         }
+        Ok(())
     }
 
     #[test]
-    fn parse_source_npm_unpinned() {
+    fn parse_source_npm_unpinned() -> std::result::Result<(), String> {
         let dir = tempfile::tempdir().expect("tempdir");
-        match parse_source("npm:express", dir.path()) {
-            ParsedSource::Npm { pinned, .. } => {
-                assert!(!pinned);
-            }
-            other => panic!("Unexpected parsed source: {:?}", other),
+        for source in [
+            "npm:express",
+            "npm:express@latest",
+            "npm:express@^4.0.0",
+            "npm:express@~4.0.0",
+            "npm:express@=4.0.0",
+            "npm:express@file:../express",
+        ] {
+            let ParsedSource::Npm { pinned, .. } = parse_source(source, dir.path()) else {
+                return Err(format!("unexpected parsed source for {source}"));
+            };
+            assert!(!pinned, "{source} should remain updateable");
         }
+        Ok(())
     }
 
     #[test]
@@ -7180,6 +7234,55 @@ mod tests {
             digest_sha256: digest.to_string(),
             trust_state: PackageEntryTrustState::Trusted,
         }
+    }
+
+    #[test]
+    fn build_npm_lock_entry_uses_normalized_exact_versions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cwd = dir.path().to_path_buf();
+        let installed = cwd
+            .join(".pi")
+            .join("npm")
+            .join("node_modules")
+            .join("demo-pkg");
+        fs::create_dir_all(&installed).expect("create installed package");
+        fs::write(
+            installed.join("package.json"),
+            br#"{"name":"demo-pkg","version":"1.2.3"}"#,
+        )
+        .expect("write package metadata");
+        fs::write(installed.join("index.js"), "export default {};\n")
+            .expect("write package content");
+
+        let manager = PackageManager::new(cwd);
+        for (source, expected_pinned) in [
+            ("npm:demo-pkg@1.2.3", true),
+            ("npm:demo-pkg@v1.2.3", true),
+            ("npm:demo-pkg@=1.2.3", false),
+            ("npm:demo-pkg@1.2", false),
+            ("npm:demo-pkg@latest", false),
+            ("npm:demo-pkg@beta", false),
+            ("npm:demo-pkg@file:../demo-pkg", false),
+        ] {
+            let entry = manager
+                .build_lock_entry(source, PackageScope::Project)
+                .unwrap_or_else(|error| panic!("{source} should build a lock entry: {error}"));
+            let PackageResolvedProvenance::Npm { pinned, .. } = entry.resolved else {
+                panic!("{source} should produce npm provenance");
+            };
+            assert_eq!(
+                pinned, expected_pinned,
+                "unexpected pinned state for {source}"
+            );
+        }
+
+        let error = manager
+            .build_lock_entry("npm:demo-pkg@v1.2.4", PackageScope::Project)
+            .expect_err("a mismatched exact version must fail lock verification");
+        assert!(
+            error.to_string().contains("npm_version_mismatch"),
+            "unexpected exact-version mismatch: {error}"
+        );
     }
 
     #[test]

--- a/tests/e2e_cli.rs
+++ b/tests/e2e_cli.rs
@@ -37,6 +37,10 @@ const FAKE_NPM_SCRIPT: &str = r#"#!/bin/sh
 set -eu
 
 cmd="${1:-}"
+if [ -n "${PI_TEST_NPM_LOG:-}" ]; then
+    printf '%s\n' "$*" >> "$PI_TEST_NPM_LOG"
+fi
+
 if [ "$cmd" = "root" ] && [ "${2:-}" = "-g" ]; then
     printf '%s\n' "${npm_config_prefix:-$PWD/.fake-npm-global}/lib/node_modules"
     exit 0
@@ -1206,6 +1210,52 @@ fn e2e_cli_config_subcommand_json_output() {
         payload.get("configValid").is_some(),
         "missing configValid flag"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_cli_config_resolves_global_npm_root_once() {
+    let mut harness = CliTestHarness::new("e2e_cli_config_resolves_global_npm_root_once");
+    let npm_log = harness.harness.temp_path("npm.log");
+    harness
+        .env
+        .insert("PI_TEST_NPM_LOG".to_string(), npm_log.display().to_string());
+
+    let global_node_modules = PathBuf::from(
+        harness
+            .env
+            .get("npm_config_prefix")
+            .expect("isolated npm prefix"),
+    )
+    .join("lib")
+    .join("node_modules");
+    for package in ["first-package", "second-package"] {
+        let package_dir = global_node_modules.join(package);
+        fs::create_dir_all(&package_dir).expect("create global npm package");
+        fs::write(
+            package_dir.join("package.json"),
+            serde_json::to_vec(&json!({
+                "name": package,
+                "version": "1.0.0",
+            }))
+            .expect("serialize npm package"),
+        )
+        .expect("write npm package");
+    }
+    fs::write(
+        harness.global_settings_path(),
+        serde_json::to_vec(&json!({
+            "packages": ["npm:first-package", "npm:second-package"],
+        }))
+        .expect("serialize settings"),
+    )
+    .expect("write settings");
+
+    let result = harness.run(&["config", "--json"]);
+
+    assert_exit_code(&harness.harness, &result, 0);
+    let npm_commands = fs::read_to_string(npm_log).expect("read npm command log");
+    assert_eq!(npm_commands, "root -g\n");
 }
 
 #[test]

--- a/tests/e2e_cli.rs
+++ b/tests/e2e_cli.rs
@@ -1264,8 +1264,8 @@ fn e2e_cli_config_resolves_global_npm_root_once() {
     let npm_log = configure_global_npm_packages(
         &mut harness,
         &[
-            ("npm:first-package", "first-package"),
-            ("npm:second-package", "second-package"),
+            ("npm:first-package@^1.0.0", "first-package"),
+            ("npm:second-package@~1.0.0", "second-package"),
         ],
     );
 
@@ -1283,8 +1283,8 @@ fn e2e_cli_json_mode_resolves_global_npm_root_once() {
     let npm_log = configure_global_npm_packages(
         &mut harness,
         &[
-            ("npm:first-package@1.0.0", "first-package"),
-            ("npm:second-package@1.0.0", "second-package"),
+            ("npm:first-package@latest", "first-package"),
+            ("npm:second-package@next", "second-package"),
         ],
     );
 

--- a/tests/e2e_cli.rs
+++ b/tests/e2e_cli.rs
@@ -1213,9 +1213,10 @@ fn e2e_cli_config_subcommand_json_output() {
 }
 
 #[cfg(unix)]
-#[test]
-fn e2e_cli_config_resolves_global_npm_root_once() {
-    let mut harness = CliTestHarness::new("e2e_cli_config_resolves_global_npm_root_once");
+fn configure_global_npm_packages(
+    harness: &mut CliTestHarness,
+    packages: &[(&str, &str)],
+) -> PathBuf {
     let npm_log = harness.harness.temp_path("npm.log");
     harness
         .env
@@ -1229,29 +1230,78 @@ fn e2e_cli_config_resolves_global_npm_root_once() {
     )
     .join("lib")
     .join("node_modules");
-    for package in ["first-package", "second-package"] {
-        let package_dir = global_node_modules.join(package);
+    for &(_, package_name) in packages {
+        let package_dir = global_node_modules.join(package_name);
         fs::create_dir_all(&package_dir).expect("create global npm package");
         fs::write(
             package_dir.join("package.json"),
             serde_json::to_vec(&json!({
-                "name": package,
+                "name": package_name,
                 "version": "1.0.0",
             }))
             .expect("serialize npm package"),
         )
         .expect("write npm package");
     }
+
+    let sources = packages
+        .iter()
+        .map(|&(source, _)| source)
+        .collect::<Vec<_>>();
     fs::write(
         harness.global_settings_path(),
-        serde_json::to_vec(&json!({
-            "packages": ["npm:first-package", "npm:second-package"],
-        }))
-        .expect("serialize settings"),
+        serde_json::to_vec(&json!({ "packages": sources })).expect("serialize settings"),
     )
     .expect("write settings");
 
+    npm_log
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_cli_config_resolves_global_npm_root_once() {
+    let mut harness = CliTestHarness::new("e2e_cli_config_resolves_global_npm_root_once");
+    let npm_log = configure_global_npm_packages(
+        &mut harness,
+        &[
+            ("npm:first-package", "first-package"),
+            ("npm:second-package", "second-package"),
+        ],
+    );
+
     let result = harness.run(&["config", "--json"]);
+
+    assert_exit_code(&harness.harness, &result, 0);
+    let npm_commands = fs::read_to_string(npm_log).expect("read npm command log");
+    assert_eq!(npm_commands, "root -g\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_cli_json_mode_resolves_global_npm_root_once() {
+    let mut harness = CliTestHarness::new("e2e_cli_json_mode_resolves_global_npm_root_once");
+    let npm_log = configure_global_npm_packages(
+        &mut harness,
+        &[
+            ("npm:first-package@1.0.0", "first-package"),
+            ("npm:second-package@1.0.0", "second-package"),
+        ],
+    );
+
+    let result = harness.run(&[
+        "--mode",
+        "json",
+        "--provider",
+        "anthropic",
+        "--model",
+        "claude-sonnet-4-5",
+        "--api-key",
+        "test-api-key",
+        "--no-tools",
+        "--no-skills",
+        "--no-prompt-templates",
+        "--no-themes",
+    ]);
 
     assert_exit_code(&harness.harness, &result, 0);
     let npm_commands = fs::read_to_string(npm_log).expect("read npm command log");

--- a/tests/package_manager.rs
+++ b/tests/package_manager.rs
@@ -171,67 +171,6 @@ fn installed_path_resolves_project_and_user_scopes_without_external_commands() {
 }
 
 #[test]
-fn resolve_with_roots_preserves_installed_dist_tagged_npm_package() {
-    let harness =
-        TestHarness::new("resolve_with_roots_preserves_installed_dist_tagged_npm_package");
-    let cwd = harness.create_dir("cwd");
-    let manager = PackageManager::new(cwd.clone());
-
-    let global_base_dir = harness.create_dir("global");
-    let project_base_dir = cwd.join(".pi");
-    let installed_package = project_base_dir
-        .join("npm")
-        .join("node_modules")
-        .join("typescript");
-    let extension = installed_package.join("extensions").join("offline.js");
-    std::fs::create_dir_all(extension.parent().expect("extension parent"))
-        .expect("create installed package");
-    std::fs::write(&extension, "export default function init() {}\n").expect("write extension");
-    write_json(
-        &installed_package.join("package.json"),
-        &serde_json::json!({
-            "name": "typescript",
-            "version": "0.0.0",
-            "pi": {
-                "extensions": ["extensions/offline.js"]
-            }
-        }),
-    );
-
-    let global_settings_path = global_base_dir.join("settings.json");
-    let project_settings_path = project_base_dir.join("settings.json");
-    write_json(&global_settings_path, &serde_json::json!({}));
-    write_json(
-        &project_settings_path,
-        &serde_json::json!({ "packages": ["npm:typescript@latest"] }),
-    );
-
-    let roots = ResolveRoots {
-        project_settings_enabled: true,
-        global_settings_path,
-        project_settings_path,
-        global_base_dir,
-        project_base_dir,
-    };
-    let resolved =
-        run_async(manager.resolve_with_roots(&roots)).expect("resolve installed package");
-
-    let entry = resolved
-        .extensions
-        .iter()
-        .find(|entry| entry.path == extension)
-        .expect("installed package extension");
-    assert!(entry.enabled);
-    assert_eq!(entry.metadata.scope, PackageScope::Project);
-    assert_eq!(entry.metadata.source, "npm:typescript@latest");
-    assert_eq!(
-        std::fs::read_to_string(&entry.path).expect("read preserved extension"),
-        "export default function init() {}\n",
-        "normal resolution must not replace an installed unpinned package"
-    );
-}
-
-#[test]
 fn resolve_with_roots_auto_discovery_ignores_parent_gitignore() {
     let harness = TestHarness::new("resolve_with_roots_auto_discovery_ignores_parent_gitignore");
 

--- a/tests/package_manager.rs
+++ b/tests/package_manager.rs
@@ -171,8 +171,9 @@ fn installed_path_resolves_project_and_user_scopes_without_external_commands() {
 }
 
 #[test]
-fn resolve_with_roots_uses_installed_unpinned_npm_package() {
-    let harness = TestHarness::new("resolve_with_roots_uses_installed_unpinned_npm_package");
+fn resolve_with_roots_preserves_installed_dist_tagged_npm_package() {
+    let harness =
+        TestHarness::new("resolve_with_roots_preserves_installed_dist_tagged_npm_package");
     let cwd = harness.create_dir("cwd");
     let manager = PackageManager::new(cwd.clone());
 
@@ -202,7 +203,7 @@ fn resolve_with_roots_uses_installed_unpinned_npm_package() {
     write_json(&global_settings_path, &serde_json::json!({}));
     write_json(
         &project_settings_path,
-        &serde_json::json!({ "packages": ["npm:typescript"] }),
+        &serde_json::json!({ "packages": ["npm:typescript@latest"] }),
     );
 
     let roots = ResolveRoots {
@@ -222,7 +223,7 @@ fn resolve_with_roots_uses_installed_unpinned_npm_package() {
         .expect("installed package extension");
     assert!(entry.enabled);
     assert_eq!(entry.metadata.scope, PackageScope::Project);
-    assert_eq!(entry.metadata.source, "npm:typescript");
+    assert_eq!(entry.metadata.source, "npm:typescript@latest");
     assert_eq!(
         std::fs::read_to_string(&entry.path).expect("read preserved extension"),
         "export default function init() {}\n",

--- a/tests/package_manager.rs
+++ b/tests/package_manager.rs
@@ -171,6 +171,66 @@ fn installed_path_resolves_project_and_user_scopes_without_external_commands() {
 }
 
 #[test]
+fn resolve_with_roots_uses_installed_unpinned_npm_package() {
+    let harness = TestHarness::new("resolve_with_roots_uses_installed_unpinned_npm_package");
+    let cwd = harness.create_dir("cwd");
+    let manager = PackageManager::new(cwd.clone());
+
+    let global_base_dir = harness.create_dir("global");
+    let project_base_dir = cwd.join(".pi");
+    let installed_package = project_base_dir
+        .join("npm")
+        .join("node_modules")
+        .join("typescript");
+    let extension = installed_package.join("extensions").join("offline.js");
+    std::fs::create_dir_all(extension.parent().expect("extension parent"))
+        .expect("create installed package");
+    std::fs::write(&extension, "export default function init() {}\n").expect("write extension");
+    write_json(
+        &installed_package.join("package.json"),
+        &serde_json::json!({
+            "name": "typescript",
+            "version": "0.0.0",
+            "pi": {
+                "extensions": ["extensions/offline.js"]
+            }
+        }),
+    );
+
+    let global_settings_path = global_base_dir.join("settings.json");
+    let project_settings_path = project_base_dir.join("settings.json");
+    write_json(&global_settings_path, &serde_json::json!({}));
+    write_json(
+        &project_settings_path,
+        &serde_json::json!({ "packages": ["npm:typescript"] }),
+    );
+
+    let roots = ResolveRoots {
+        project_settings_enabled: true,
+        global_settings_path,
+        project_settings_path,
+        global_base_dir,
+        project_base_dir,
+    };
+    let resolved =
+        run_async(manager.resolve_with_roots(&roots)).expect("resolve installed package");
+
+    let entry = resolved
+        .extensions
+        .iter()
+        .find(|entry| entry.path == extension)
+        .expect("installed package extension");
+    assert!(entry.enabled);
+    assert_eq!(entry.metadata.scope, PackageScope::Project);
+    assert_eq!(entry.metadata.source, "npm:typescript");
+    assert_eq!(
+        std::fs::read_to_string(&entry.path).expect("read preserved extension"),
+        "export default function init() {}\n",
+        "normal resolution must not replace an installed unpinned package"
+    );
+}
+
+#[test]
 fn resolve_with_roots_auto_discovery_ignores_parent_gitignore() {
     let harness = TestHarness::new("resolve_with_roots_auto_discovery_ignores_parent_gitignore");
 


### PR DESCRIPTION
## Summary

Normal startup no longer checks the npm registry for packages that are already installed. Pi resolves the global npm root once per settings-resolution pass, reads each installed `package.json`, and installs only packages that are missing or do not satisfy a conventional exact or range spec. Bare specs, dist-tags, local references, and unrecognized spec forms remain untouched until `pi update`.

This applies to both the blocking config-report path and the async startup path. It also intentionally aligns update behavior with the [upstream TypeScript implementation](https://github.com/earendil-works/pi/blob/5bc1c2c0a6f07e00e8c240304182f213ab8d311f/packages/coding-agent/src/core/package-manager.ts): exact versions are pinned, while ranges and dist-tags may refresh. The resolved root is scoped to one pass; there is no process-wide cache or new shared mutable state.

For five installed floating packages, the old path made five registry requests and ran `npm root -g` five times. The new path removes all five requests and four redundant subprocesses. Seven warm local component samples measured 61–89 ms per registry request and 40–50 ms per root lookup, implying roughly 0.47–0.65 seconds saved for that startup shape. This is a component-based estimate, not an end-to-end benchmark.

## Dependency choice

Rust's `semver` crate does not implement npm's full range language, including whitespace intersections, `||`, and hyphen ranges. [`deno_semver` 0.10.1](https://github.com/denoland/deno_semver) handles the conventional npm forms needed here without invoking npm or JavaScript during startup. Malformed-input behavior is not claimed to be byte-for-byte identical to npm.

A zero-dependency alternative was evaluated, but its MIT-0 license is outside the required Rust license policy. `deno_semver` adds ten lockfile packages; all declare MIT or dual MIT/Apache-2.0 licenses.

## Diff size

Production Rust is `+140/-124`: a net increase of 16 lines. The rest is tests (`+270/-19`), generated lockfile metadata (`+103`), and one manifest line. Total: `+514/-143`.

## Verification

- 201 package-manager unit tests and 129 integration tests pass.
- Sync and async E2Es cover ranges and dist-tags, recording one `npm root -g` and no install/update command for two installed packages.
- The former registry helper and its only startup call site are removed; the E2Es record subprocesses rather than intercepting Rust HTTP traffic.
- 6,698 library tests pass with two unrelated loopback/socket tests filtered.
- `cargo check --all-targets --locked` passes. All-target Clippy passes with the five pre-existing `src/acp.rs` `future_not_send` findings allowed. Changed Rust files pass rustfmt.
- UBS finds nothing on changed lines; the dependency-license delta and beads ledger reconciliation pass.
