### PR TITLE
feat(provider): add Atlas Cloud preset

### DIFF
--- a/docs/provider-canonical-id-table.json
+++ b/docs/provider-canonical-id-table.json
@@ -91,6 +91,24 @@
       }
     },
     {
+      "aliases": [
+        "cursor-agent"
+      ],
+      "auth_env_keys": [
+        "CURSOR_API_KEY",
+        "CURSOR_ACCESS_TOKEN"
+      ],
+      "canonical_id": "cursor",
+      "onboarding_mode": "built-in-native",
+      "routing": {
+        "api": "cursor-agent",
+        "auth_header": true,
+        "base_url": "https://api2.cursor.sh/agent.v1.AgentService/Run",
+        "context_window": 200000,
+        "max_tokens": 64000
+      }
+    },
+    {
       "aliases": [],
       "auth_env_keys": [
         "GROQ_API_KEY"
@@ -150,6 +168,25 @@
         "api": "openai-completions",
         "auth_header": true,
         "base_url": "https://openrouter.ai/api/v1",
+        "context_window": 128000,
+        "max_tokens": 16384
+      }
+    },
+    {
+      "aliases": [
+        "atlas-cloud",
+        "atlas"
+      ],
+      "auth_env_keys": [
+        "ATLASCLOUD_API_KEY",
+        "ATLAS_CLOUD_API_KEY"
+      ],
+      "canonical_id": "atlascloud",
+      "onboarding_mode": "oai-compatible-preset",
+      "routing": {
+        "api": "openai-completions",
+        "auth_header": true,
+        "base_url": "https://api.atlascloud.ai/v1",
         "context_window": 128000,
         "max_tokens": 16384
       }
@@ -833,6 +870,22 @@
       }
     },
     {
+      "aliases": [],
+      "auth_env_keys": [
+        "DASHSCOPE_API_KEY",
+        "QWEN_API_KEY"
+      ],
+      "canonical_id": "alibaba-us",
+      "onboarding_mode": "oai-compatible-preset",
+      "routing": {
+        "api": "openai-completions",
+        "auth_header": true,
+        "base_url": "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
+        "context_window": 128000,
+        "max_tokens": 16384
+      }
+    },
+    {
       "aliases": [
         "kimi-coding",
         "kimi-code"
@@ -1186,6 +1239,39 @@
       }
     },
     {
+      "aliases": [
+        "llama-cpp",
+        "llama.cpp",
+        "llama-server"
+      ],
+      "auth_env_keys": [],
+      "canonical_id": "llamacpp",
+      "onboarding_mode": "oai-compatible-preset",
+      "routing": {
+        "api": "openai-completions",
+        "auth_header": false,
+        "base_url": "http://127.0.0.1:8080/v1",
+        "context_window": 131072,
+        "max_tokens": 32768
+      }
+    },
+    {
+      "aliases": [
+        "mistral.rs",
+        "mistral-rs"
+      ],
+      "auth_env_keys": [],
+      "canonical_id": "mistralrs",
+      "onboarding_mode": "oai-compatible-preset",
+      "routing": {
+        "api": "openai-completions",
+        "auth_header": false,
+        "base_url": "http://127.0.0.1:1234/v1",
+        "context_window": 131072,
+        "max_tokens": 32768
+      }
+    },
+    {
       "aliases": [],
       "auth_env_keys": [
         "OLLAMA_API_KEY"
@@ -1343,6 +1429,7 @@
     {
       "aliases": [
         "azure",
+        "azure_openai",
         "azure-cognitive-services",
         "azure-openai-responses"
       ],
@@ -1377,6 +1464,6 @@
     }
   ],
   "schema_version": "1.0",
-  "total_aliases": 42,
-  "total_providers": 90
+  "total_aliases": 51,
+  "total_providers": 95
 }

--- a/src/provider_metadata.rs
+++ b/src/provider_metadata.rs
@@ -240,6 +240,23 @@ pub const PROVIDER_METADATA: &[ProviderMetadata] = &[
         test_obligations: TEST_REQUIRED,
     },
     ProviderMetadata {
+        canonical_id: "atlascloud",
+        display_name: Some("Atlas Cloud"),
+        aliases: &["atlas-cloud", "atlas"],
+        auth_env_keys: &["ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY"],
+        onboarding: ProviderOnboardingMode::OpenAICompatiblePreset,
+        routing_defaults: Some(ProviderRoutingDefaults {
+            api: "openai-completions",
+            base_url: "https://api.atlascloud.ai/v1",
+            auth_header: true,
+            reasoning: true,
+            input: &INPUT_TEXT,
+            context_window: 128_000,
+            max_tokens: 16_384,
+        }),
+        test_obligations: TEST_REQUIRED,
+    },
+    ProviderMetadata {
         canonical_id: "mistral",
         display_name: Some("Mistral AI"),
         aliases: &["mistralai"],
@@ -1747,6 +1764,11 @@ mod tests {
         let openrouter_alias =
             provider_metadata("open-router").expect("open-router alias metadata");
         assert_eq!(openrouter_alias.canonical_id, "openrouter");
+        let atlas_alias = provider_metadata("atlas").expect("atlas alias metadata");
+        assert_eq!(atlas_alias.canonical_id, "atlascloud");
+        let atlas_cloud_alias =
+            provider_metadata("atlas-cloud").expect("atlas-cloud alias metadata");
+        assert_eq!(atlas_cloud_alias.canonical_id, "atlascloud");
         let vercel_gateway_alias =
             provider_metadata("vercel-ai-gateway").expect("vercel alias metadata");
         assert_eq!(vercel_gateway_alias.canonical_id, "vercel");
@@ -1862,6 +1884,14 @@ mod tests {
         assert_eq!(
             provider_auth_env_keys("open-router"),
             &["OPENROUTER_API_KEY"]
+        );
+        assert_eq!(
+            provider_auth_env_keys("atlascloud"),
+            &["ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY"]
+        );
+        assert_eq!(
+            provider_auth_env_keys("atlas-cloud"),
+            &["ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY"]
         );
         assert_eq!(
             provider_auth_env_keys("vercel-ai-gateway"),

--- a/tests/provider_factory.rs
+++ b/tests/provider_factory.rs
@@ -1371,6 +1371,82 @@ fn create_provider_cloudflare_ai_gateway_routes_via_openai_compat() {
 }
 
 #[test]
+fn atlascloud_preset_resolves_openai_compat_defaults_and_factory_route() {
+    let defaults = provider_routing_defaults("atlascloud").expect("atlascloud defaults");
+    assert_eq!(defaults.api, "openai-completions");
+    assert_eq!(defaults.base_url, "https://api.atlascloud.ai/v1");
+    assert!(defaults.auth_header);
+    assert_eq!(canonical_provider_id("atlas-cloud"), Some("atlascloud"));
+    assert_eq!(canonical_provider_id("atlas"), Some("atlascloud"));
+    assert_eq!(
+        provider_auth_env_keys("atlascloud"),
+        &["ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY"]
+    );
+
+    let mut entry = make_model_entry(
+        "atlascloud",
+        "deepseek-ai/deepseek-v4-pro",
+        defaults.base_url,
+    );
+    entry.model.api.clear();
+    let provider = create_provider(&entry, None).expect("atlascloud provider");
+    assert_eq!(provider.name(), "atlascloud");
+    assert_eq!(provider.api(), "openai-completions");
+    assert_eq!(provider.model_id(), "deepseek-ai/deepseek-v4-pro");
+}
+
+#[test]
+fn atlascloud_stream_uses_chat_completions_path_and_bearer_auth() {
+    let harness = TestHarness::new("atlascloud_stream_uses_chat_completions_path_and_bearer_auth");
+    let server = harness.start_mock_http_server();
+    server.add_route(
+        "POST",
+        "/v1/chat/completions",
+        text_event_stream_response(openai_chat_sse_body()),
+    );
+
+    let mut entry = make_model_entry(
+        "atlascloud",
+        "deepseek-ai/deepseek-v4-pro",
+        &format!("{}/v1", server.base_url()),
+    );
+    entry.model.api.clear();
+    let provider = create_provider(&entry, None).expect("atlascloud provider");
+    let context = Context {
+        system_prompt: Some("Be concise.".to_string().into()),
+        messages: vec![Message::User(UserMessage {
+            content: UserContent::Text("Ping".to_string()),
+            timestamp: 0,
+        })]
+        .into(),
+        tools: Vec::new().into(),
+    };
+    let options = StreamOptions {
+        api_key: Some("atlas-test-token".to_string()),
+        max_tokens: Some(512),
+        ..Default::default()
+    };
+    drive_provider_stream_to_done(provider, context, options);
+
+    let requests = server.requests();
+    assert_eq!(
+        requests.len(),
+        1,
+        "expected exactly one Atlas Cloud request"
+    );
+    let request = &requests[0];
+    assert_eq!(request.path, "/v1/chat/completions");
+    assert_eq!(
+        request_header(&request.headers, "authorization").as_deref(),
+        Some("Bearer atlas-test-token")
+    );
+    assert_eq!(
+        request_header(&request.headers, "content-type").as_deref(),
+        Some("application/json")
+    );
+}
+
+#[test]
 fn wave_a_presets_resolve_openai_compat_defaults_and_factory_route() {
     let harness =
         TestHarness::new("wave_a_presets_resolve_openai_compat_defaults_and_factory_route");

--- a/tests/provider_metadata_comprehensive.rs
+++ b/tests/provider_metadata_comprehensive.rs
@@ -121,6 +121,9 @@ fn every_remote_provider_has_at_least_one_auth_env_key() {
     let auth_env_optional_providers = [
         "google-antigravity",
         "google-gemini-cli",
+        "llamacpp",
+        "lmstudio",
+        "mistralrs",
         "ollama",
         "openai-codex",
     ];
@@ -269,6 +272,8 @@ fn all_oai_compatible_base_urls_are_unique() {
         ("minimax-coding-plan", "minimax"),
         ("minimax-cn", "minimax-cn-coding-plan"),
         ("minimax-cn-coding-plan", "minimax-cn"),
+        ("lmstudio", "mistralrs"),
+        ("mistralrs", "lmstudio"),
     ]);
     for meta in PROVIDER_METADATA {
         if let Some(defaults) = &meta.routing_defaults {
@@ -302,6 +307,7 @@ fn oai_compatible_defaults_use_known_api_family() {
         "bedrock-converse-stream",
         "gitlab-chat",
         "copilot-openai",
+        "cursor-agent",
     ];
     for meta in PROVIDER_METADATA {
         if let Some(defaults) = &meta.routing_defaults {
@@ -632,7 +638,7 @@ fn generate_canonical_id_alias_table_json() {
 #[test]
 #[allow(clippy::too_many_lines)]
 fn canonical_id_snapshot_detects_additions_and_removals() {
-    // ── Snapshot: 91 canonical IDs (sorted) ─────────────────────────────
+    // ── Snapshot: 95 canonical IDs (sorted) ─────────────────────────────
     // To update: run the failing test, copy the "actual" list printed
     // below, and replace this array.
     const EXPECTED: &[&str] = &[
@@ -644,6 +650,7 @@ fn canonical_id_snapshot_detects_additions_and_removals() {
         "alibaba-us",
         "amazon-bedrock",
         "anthropic",
+        "atlascloud",
         "azure-openai",
         "bailing",
         "baseten",
@@ -654,6 +661,7 @@ fn canonical_id_snapshot_detects_additions_and_removals() {
         "cloudflare-workers-ai",
         "cohere",
         "cortecs",
+        "cursor",
         "deepinfra",
         "deepseek",
         "fastrouter",
@@ -677,6 +685,7 @@ fn canonical_id_snapshot_detects_additions_and_removals() {
         "jiekou",
         "kimi-for-coding",
         "llama",
+        "llamacpp",
         "lmstudio",
         "lucidquery",
         "minimax",
@@ -684,6 +693,7 @@ fn canonical_id_snapshot_detects_additions_and_removals() {
         "minimax-cn-coding-plan",
         "minimax-coding-plan",
         "mistral",
+        "mistralrs",
         "moark",
         "modelscope",
         "moonshotai",
@@ -754,6 +764,8 @@ fn alias_mapping_snapshot_is_current() {
     // ── Snapshot: alias → canonical_id (sorted by alias) ────────────────
     const EXPECTED_ALIASES: &[(&str, &str)] = &[
         ("antigravity", "google-antigravity"),
+        ("atlas", "atlascloud"),
+        ("atlas-cloud", "atlascloud"),
         ("azure", "azure-openai"),
         ("azure-cognitive-services", "azure-openai"),
         ("azure-openai-responses", "azure-openai"),
@@ -762,6 +774,7 @@ fn alias_mapping_snapshot_is_current() {
         ("chatgpt-codex", "openai-codex"),
         ("codex", "openai-codex"),
         ("copilot", "github-copilot"),
+        ("cursor-agent", "cursor"),
         ("dashscope", "alibaba"),
         ("deep-infra", "deepinfra"),
         ("deep-seek", "deepseek"),
@@ -778,7 +791,12 @@ fn alias_mapping_snapshot_is_current() {
         ("kimi", "moonshotai"),
         ("kimi-code", "kimi-for-coding"),
         ("kimi-coding", "kimi-for-coding"),
+        ("llama-cpp", "llamacpp"),
+        ("llama-server", "llamacpp"),
+        ("llama.cpp", "llamacpp"),
         ("lm-studio", "lmstudio"),
+        ("mistral-rs", "mistralrs"),
+        ("mistral.rs", "mistralrs"),
         ("mistralai", "mistral"),
         ("moonshot", "moonshotai"),
         ("nanogpt", "nano-gpt"),
@@ -974,6 +992,7 @@ fn no_accidental_duplicate_routing_defaults() {
     let intentional_pairs: HashSet<&str> = [
         "minimax-coding-plan",
         "minimax-cn-coding-plan",
+        "mistralrs",
         "zai-coding-plan",
         "zhipuai-coding-plan",
     ]


### PR DESCRIPTION
## Summary

- add Atlas Cloud as a canonical OpenAI-compatible provider preset with `atlas-cloud` and `atlas` aliases
- use the existing chat-completions adapter with `https://api.atlascloud.ai/v1` and the supported API-key environment variables
- cover factory routing, request path, bearer authentication, and provider metadata snapshots
- refresh the generated canonical provider table and stale metadata expectations to match the current source registry

## Validation

- `cargo test --lib provider_metadata::tests` (60 passed)
- `cargo test --test provider_factory atlascloud` (2 passed)
- `cargo test --test provider_metadata_comprehensive` (143 passed)
- `cargo check --lib`
- `git diff --check`
- Atlas Cloud public `/v1/models` catalog probe (121 text models; `deepseek-ai/deepseek-v4-pro` present)

## Documentation scope

No README, logo, sponsor, credits, or partner promotion changes. The only documentation artifact changed is the existing machine-readable canonical provider table.