### PR TITLE
feat(anthropic): cache the system prompt and tool definitions

### DIFF
--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -36,6 +36,10 @@ const ANTHROPIC_OAUTH_BETA_FLAGS: &str = "claude-code-20250219,oauth-2025-04-20"
 /// Beta flag for Anthropic prompt caching.
 /// Override via `PI_ANTHROPIC_CACHE_BETA_FLAG`.
 const ANTHROPIC_CACHE_BETA_FLAG: &str = "prompt-caching-2024-07-31";
+/// Beta flag gating the 1-hour cache TTL. Sent only when a request actually
+/// carries `"ttl": "1h"`; the API rejects that field without the flag.
+/// Override via `PI_ANTHROPIC_EXTENDED_CACHE_TTL_BETA_FLAG`.
+const ANTHROPIC_EXTENDED_CACHE_TTL_BETA_FLAG: &str = "extended-cache-ttl-2025-04-11";
 const KIMI_SHARE_DIR_ENV_KEY: &str = "KIMI_SHARE_DIR";
 
 fn anthropic_oauth_beta_flags() -> String {
@@ -50,6 +54,37 @@ fn anthropic_cache_beta_flag() -> String {
         .ok()
         .filter(|v| !v.is_empty())
         .unwrap_or_else(|| ANTHROPIC_CACHE_BETA_FLAG.to_string())
+}
+
+fn anthropic_extended_cache_ttl_beta_flag() -> String {
+    std::env::var("PI_ANTHROPIC_EXTENDED_CACHE_TTL_BETA_FLAG")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| ANTHROPIC_EXTENDED_CACHE_TTL_BETA_FLAG.to_string())
+}
+
+/// Flags for the `anthropic-beta` request header. Empty means the header is
+/// omitted entirely.
+fn anthropic_beta_flags(
+    oauth_bearer_token: bool,
+    cache_retention: CacheRetention,
+    base_url: &str,
+) -> Vec<String> {
+    let mut flags = Vec::new();
+    if oauth_bearer_token {
+        flags.push(anthropic_oauth_beta_flags());
+    }
+    if cache_retention != CacheRetention::None {
+        flags.push(anthropic_cache_beta_flag());
+        // Derived from the same helper that builds the body, so the flag cannot
+        // drift out of sync with whether `ttl` is actually serialized.
+        if AnthropicCacheControl::for_retention(cache_retention, base_url)
+            .is_some_and(AnthropicCacheControl::needs_extended_ttl_beta)
+        {
+            flags.push(anthropic_extended_cache_ttl_beta_flag());
+        }
+    }
+    flags
 }
 
 #[inline]
@@ -421,16 +456,27 @@ impl AnthropicProvider {
             .map(convert_message_to_anthropic)
             .collect();
 
+        // Cache breakpoints go on the longest stable prefix: the system prompt
+        // and the tool definitions. Both are byte-identical across turns within
+        // a session, so marking them lets every turn after the first read the
+        // prefix from cache instead of re-billing it at full input rate.
+        let cache_control =
+            AnthropicCacheControl::for_retention(options.cache_retention, &self.base_url);
+
         let tools: Option<Vec<AnthropicTool<'_>>> = if context.tools.is_empty() {
             None
         } else {
-            Some(
-                context
-                    .tools
-                    .iter()
-                    .map(convert_tool_to_anthropic)
-                    .collect(),
-            )
+            let mut tools: Vec<AnthropicTool<'_>> = context
+                .tools
+                .iter()
+                .map(convert_tool_to_anthropic)
+                .collect();
+            // One marker on the final tool covers the whole array; Anthropic
+            // caches everything preceding the marked block.
+            if let Some(last) = tools.last_mut() {
+                last.cache_control = cache_control;
+            }
+            Some(tools)
         };
 
         // Decide between the modern adaptive-thinking API and the legacy
@@ -510,7 +556,13 @@ impl AnthropicProvider {
         AnthropicRequest {
             model: &self.model,
             messages,
-            system: context.system_prompt.as_deref(),
+            system: context.system_prompt.as_deref().map(|text| {
+                vec![AnthropicSystemBlock {
+                    kind: "text",
+                    text,
+                    cache_control,
+                }]
+            }),
             max_tokens,
             temperature,
             tools,
@@ -615,13 +667,11 @@ impl Provider for AnthropicProvider {
             }
         }
 
-        let mut beta_flags: Vec<String> = Vec::new();
-        if anthropic_bearer_token {
-            beta_flags.push(anthropic_oauth_beta_flags());
-        }
-        if options.cache_retention != CacheRetention::None {
-            beta_flags.push(anthropic_cache_beta_flag());
-        }
+        let beta_flags = anthropic_beta_flags(
+            anthropic_bearer_token,
+            options.cache_retention,
+            &self.base_url,
+        );
         if !beta_flags.is_empty() {
             request = request.header("anthropic-beta", beta_flags.join(","));
         }
@@ -1080,7 +1130,7 @@ pub struct AnthropicRequest<'a> {
     model: &'a str,
     messages: Vec<AnthropicMessage<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    system: Option<&'a str>,
+    system: Option<Vec<AnthropicSystemBlock<'a>>>,
     max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f32>,
@@ -1168,6 +1218,51 @@ struct AnthropicTool<'a> {
     name: &'a str,
     description: &'a str,
     input_schema: &'a serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<AnthropicCacheControl>,
+}
+
+/// A `system` prompt block. Anthropic accepts either a bare string or an array
+/// of typed blocks; only the array form can carry `cache_control`.
+#[derive(Debug, Serialize)]
+struct AnthropicSystemBlock<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    text: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<AnthropicCacheControl>,
+}
+
+/// Prompt-cache breakpoint marker. Everything *before* a marked block becomes
+/// the cache prefix; without at least one marker the API caches nothing, no
+/// matter which beta headers are sent.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct AnthropicCacheControl {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ttl: Option<&'static str>,
+}
+
+impl AnthropicCacheControl {
+    /// `None` retention yields no marker. `Long` maps to the 1-hour TTL, which
+    /// only first-party `api.anthropic.com` honours; relays reject the field.
+    fn for_retention(retention: CacheRetention, base_url: &str) -> Option<Self> {
+        match retention {
+            CacheRetention::None => None,
+            CacheRetention::Short => Some(Self { kind: "ephemeral", ttl: None }),
+            CacheRetention::Long => Some(Self {
+                kind: "ephemeral",
+                ttl: base_url.contains("api.anthropic.com").then_some("1h"),
+            }),
+        }
+    }
+
+    /// A marker carrying an explicit TTL requires the extended-cache-ttl beta
+    /// flag on the request; the default 5-minute cache does not.
+    fn needs_extended_ttl_beta(self) -> bool {
+        self.ttl.is_some()
+    }
 }
 
 // ============================================================================
@@ -1396,6 +1491,7 @@ fn convert_tool_to_anthropic(tool: &ToolDef) -> AnthropicTool<'_> {
         name: &tool.name,
         description: &tool.description,
         input_schema: &tool.parameters,
+        cache_control: None,
     }
 }
 
@@ -1499,7 +1595,12 @@ mod tests {
 
         let request = provider.build_request(&context, &options);
         assert_eq!(request.model, "claude-test");
-        assert_eq!(request.system, Some("System prompt"));
+        let system = request.system.as_ref().expect("system blocks");
+        assert_eq!(system.len(), 1);
+        assert_eq!(system[0].kind, "text");
+        assert_eq!(system[0].text, "System prompt");
+        // Default retention is None, so no breakpoint is emitted.
+        assert!(system[0].cache_control.is_none());
         assert_eq!(request.temperature, Some(1.0)); // thinking forces temperature to 1.0
         assert!(request.stream);
         assert_eq!(request.max_tokens, 13_096);
@@ -1543,7 +1644,7 @@ mod tests {
 
         let request = provider.build_request(&context, &options);
         assert_eq!(request.model, "claude-test");
-        assert_eq!(request.system, None);
+        assert!(request.system.is_none());
         assert!(request.tools.is_none());
         assert!(request.thinking.is_none());
         assert!(request.output_config.is_none());
@@ -3394,6 +3495,166 @@ mod tests {
                     let _ = state.process_event(event);
                 }
             }
+        }
+    }
+
+    #[test]
+    fn test_build_request_marks_cache_breakpoints_when_retention_short() {
+        let provider = AnthropicProvider::new("claude-test");
+        let context = Context {
+            system_prompt: Some("System prompt".to_string().into()),
+            messages: vec![Message::User(crate::model::UserMessage {
+                content: UserContent::Text("Ping".to_string()),
+                timestamp: 0,
+            })]
+            .into(),
+            tools: vec![
+                ToolDef {
+                    name: "read".to_string(),
+                    description: "Read a file.".to_string(),
+                    parameters: json!({ "type": "object" }),
+                },
+                ToolDef {
+                    name: "write".to_string(),
+                    description: "Write a file.".to_string(),
+                    parameters: json!({ "type": "object" }),
+                },
+            ]
+            .into(),
+        };
+        let options = StreamOptions {
+            cache_retention: CacheRetention::Short,
+            ..Default::default()
+        };
+
+        let request = provider.build_request(&context, &options);
+
+        let system = request.system.as_ref().expect("system blocks");
+        assert_eq!(
+            system[0].cache_control,
+            Some(AnthropicCacheControl {
+                kind: "ephemeral",
+                ttl: None
+            })
+        );
+
+        // Exactly one marker, on the final tool: it covers the whole array.
+        let tools = request.tools.as_ref().expect("tools");
+        assert!(tools[0].cache_control.is_none());
+        assert_eq!(
+            tools[1].cache_control,
+            Some(AnthropicCacheControl {
+                kind: "ephemeral",
+                ttl: None
+            })
+        );
+
+        // The marker must survive serialization; a struct field that never
+        // reaches the wire caches nothing.
+        let body = serde_json::to_string(&request).expect("serialize");
+        assert!(
+            body.contains(r#""cache_control":{"type":"ephemeral"}"#),
+            "cache_control missing from request body: {body}"
+        );
+    }
+
+    #[test]
+    fn test_build_request_emits_no_cache_control_when_retention_none() {
+        let provider = AnthropicProvider::new("claude-test");
+        let context = Context {
+            system_prompt: Some("System prompt".to_string().into()),
+            tools: vec![ToolDef {
+                name: "read".to_string(),
+                description: "Read a file.".to_string(),
+                parameters: json!({ "type": "object" }),
+            }]
+            .into(),
+            ..Default::default()
+        };
+        let options = StreamOptions::default();
+        assert_eq!(options.cache_retention, CacheRetention::None);
+
+        let request = provider.build_request(&context, &options);
+        let body = serde_json::to_string(&request).expect("serialize");
+        assert!(!body.contains("cache_control"), "unexpected marker: {body}");
+    }
+
+    #[test]
+    fn test_long_retention_sets_one_hour_ttl_only_on_first_party_base_url() {
+        let first_party = AnthropicCacheControl::for_retention(
+            CacheRetention::Long,
+            "https://api.anthropic.com/v1/messages",
+        );
+        assert_eq!(
+            first_party,
+            Some(AnthropicCacheControl {
+                kind: "ephemeral",
+                ttl: Some("1h")
+            })
+        );
+
+        // Relays reject the ttl field; degrade to the default 5-minute cache.
+        let relay = AnthropicCacheControl::for_retention(
+            CacheRetention::Long,
+            "https://openrouter.ai/api/v1/messages",
+        );
+        assert_eq!(
+            relay,
+            Some(AnthropicCacheControl {
+                kind: "ephemeral",
+                ttl: None
+            })
+        );
+    }
+
+    #[test]
+    fn test_extended_cache_ttl_beta_flag_tracks_emitted_ttl() {
+        // The flag and the `ttl` field must ship together: the flag without the
+        // field is noise, the field without the flag is a 400.
+        const FIRST_PARTY: &str = "https://api.anthropic.com/v1/messages";
+        const RELAY: &str = "https://openrouter.ai/api/v1/messages";
+
+        for (oauth, retention, base_url, expected) in [
+            (false, CacheRetention::None, FIRST_PARTY, vec![]),
+            (
+                false,
+                CacheRetention::Short,
+                FIRST_PARTY,
+                vec![ANTHROPIC_CACHE_BETA_FLAG],
+            ),
+            (
+                false,
+                CacheRetention::Long,
+                FIRST_PARTY,
+                vec![
+                    ANTHROPIC_CACHE_BETA_FLAG,
+                    ANTHROPIC_EXTENDED_CACHE_TTL_BETA_FLAG,
+                ],
+            ),
+            // Relays drop the `ttl` field, so the flag must stay off too.
+            (
+                false,
+                CacheRetention::Long,
+                RELAY,
+                vec![ANTHROPIC_CACHE_BETA_FLAG],
+            ),
+            (
+                true,
+                CacheRetention::Long,
+                FIRST_PARTY,
+                vec![
+                    ANTHROPIC_OAUTH_BETA_FLAGS,
+                    ANTHROPIC_CACHE_BETA_FLAG,
+                    ANTHROPIC_EXTENDED_CACHE_TTL_BETA_FLAG,
+                ],
+            ),
+        ] {
+            let expected: Vec<String> = expected.into_iter().map(str::to_string).collect();
+            assert_eq!(
+                anthropic_beta_flags(oauth, retention, base_url),
+                expected,
+                "oauth={oauth} retention={retention:?} base_url={base_url}"
+            );
         }
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -4210,7 +4210,7 @@ where
         let original_permissions = expected_target_identity.map(|(_, _, mode)| {
             use std::os::unix::fs::PermissionsExt as _;
 
-            std::fs::Permissions::from_mode(mode)
+            std::fs::Permissions::from_mode(u32::from(mode))
         });
 
         // The pathname stored by `NamedTempFile` is not descriptor-relative.
@@ -4307,7 +4307,7 @@ where
                 let source_file = std::fs::File::from(source_descriptor);
                 let source_metadata = source_file.metadata()?;
                 if !source_metadata.is_file()
-                    || source_metadata.dev() != expected_dev
+                    || source_metadata.dev() as i64 != expected_dev as i64
                     || source_metadata.ino() != expected_ino
                 {
                     return Err(std::io::Error::other(

--- a/tests/provider_live_verify.rs
+++ b/tests/provider_live_verify.rs
@@ -35,7 +35,7 @@ mod common;
 use common::TestHarness;
 use futures::StreamExt;
 use pi::model::{Message, StopReason, StreamEvent, UserContent, UserMessage};
-use pi::provider::{Context, Provider, StreamOptions, ToolDef};
+use pi::provider::{CacheRetention, Context, Provider, StreamOptions, ToolDef};
 use pi::provider_metadata::{PROVIDER_METADATA, ProviderMetadata, provider_auth_env_keys};
 use pi::providers::anthropic::AnthropicProvider;
 use pi::providers::cohere::CohereProvider;
@@ -171,6 +171,7 @@ async fn collect_stream_events(
                 has_start: false,
                 has_done: false,
                 stop_reason: None,
+                usage: None,
                 stream_error: Some(e.to_string()),
                 elapsed_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
             };
@@ -183,6 +184,7 @@ async fn collect_stream_events(
     let mut has_start = false;
     let mut has_done = false;
     let mut stop_reason = None;
+    let mut usage = None;
     let mut stream_error = None;
 
     while let Some(item) = stream.next().await {
@@ -198,6 +200,7 @@ async fn collect_stream_events(
                     StreamEvent::Done { reason, message } => {
                         has_done = true;
                         stop_reason = Some(*reason);
+                        usage = Some(message.usage.clone());
                         // Fall back to Done message text if no deltas were received.
                         if text.is_empty() {
                             for block in &message.content {
@@ -231,6 +234,7 @@ async fn collect_stream_events(
         has_start,
         has_done,
         stop_reason,
+        usage,
         stream_error,
         elapsed_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
     }
@@ -244,6 +248,9 @@ struct StreamResult {
     has_start: bool,
     has_done: bool,
     stop_reason: Option<StopReason>,
+    /// Token accounting from the terminal `Done` event. `None` when the stream
+    /// failed before completing.
+    usage: Option<pi::model::Usage>,
     stream_error: Option<String>,
     elapsed_ms: u64,
 }
@@ -572,6 +579,108 @@ mod anthropic {
                 text_preview: sr.text.chars().take(100).collect(),
                 tool_call_count: 0,
                 stop_reason: sr.stop_reason.map(|r| format!("{r:?}")),
+                error: None,
+            };
+            write_result_artifact(&vr);
+        });
+    }
+
+    /// Prompt-cache round trip through the real provider.
+    ///
+    /// The unit tests in `providers::anthropic` prove `build_request` emits the
+    /// JSON we intended; they cannot prove Anthropic accepts it or caches on
+    /// it. This drives the whole path — `build_request`, the `anthropic-beta`
+    /// header, serialization, the HTTP call, and usage parsing — and asserts
+    /// the API reported a cache read on the second identical request.
+    #[test]
+    fn live_prompt_cache_writes_then_reads() {
+        skip_unless_live!();
+        let (api_key, _) = skip_unless_secret!("anthropic");
+
+        common::run_async(async move {
+            // A cache entry only forms above the model's minimum cacheable
+            // prefix — 1024 tokens on Sonnet, and the prefix here is system +
+            // tools. Below that the API silently caches nothing, so the filler
+            // is sized for headroom over the floor rather than trimmed to it.
+            // The text must also be byte-identical across both calls, so the
+            // filler is deterministic.
+            let mut system_prompt =
+                String::from("You are a fixture used to verify Anthropic prompt caching. ");
+            for i in 0..110 {
+                system_prompt.push_str(&format!(
+                    "Stable prefix sentence {i}: the cache key is the exact byte prefix. "
+                ));
+            }
+
+            let provider = AnthropicProvider::new("claude-sonnet-4-5")
+                .with_base_url("https://api.anthropic.com/v1/messages");
+            let context = Context::owned(
+                Some(system_prompt),
+                vec![user_text("Reply with the single word: pong.")],
+                vec![echo_tool()],
+            );
+            let options = StreamOptions {
+                cache_retention: CacheRetention::Short,
+                ..simple_options(&api_key)
+            };
+
+            let first = collect_stream_events(&provider, &context, &options).await;
+            assert!(
+                first.stream_error.is_none(),
+                "anthropic cache write stream error: {}",
+                first.stream_error.as_deref().unwrap_or("")
+            );
+            let first_usage = first.usage.expect("anthropic: expected usage on first call");
+            // A prior run inside the 5-minute TTL leaves the entry warm, so a
+            // read here is also valid; only "neither" means caching is broken.
+            assert!(
+                first_usage.cache_write > 0 || first_usage.cache_read > 0,
+                "anthropic: first call neither wrote nor read cache \
+                 (write={}, read={}, input={})",
+                first_usage.cache_write,
+                first_usage.cache_read,
+                first_usage.input
+            );
+
+            let second = collect_stream_events(&provider, &context, &options).await;
+            assert!(
+                second.stream_error.is_none(),
+                "anthropic cache read stream error: {}",
+                second.stream_error.as_deref().unwrap_or("")
+            );
+            let second_usage = second
+                .usage
+                .expect("anthropic: expected usage on second call");
+            assert!(
+                second_usage.cache_read > 0,
+                "anthropic: second identical request did not read from cache \
+                 (write={}, read={}, input={}) — the prefix drifted or no \
+                 breakpoint reached the wire",
+                second_usage.cache_write,
+                second_usage.cache_read,
+                second_usage.input
+            );
+            // The cached prefix must not also be billed as uncached input.
+            assert!(
+                second_usage.input < second_usage.cache_read,
+                "anthropic: uncached input ({}) should be far below the cached \
+                 prefix ({})",
+                second_usage.input,
+                second_usage.cache_read
+            );
+
+            let vr = VerificationResult {
+                provider: "anthropic".into(),
+                scenario: "prompt_cache".into(),
+                passed: true,
+                elapsed_ms: first.elapsed_ms + second.elapsed_ms,
+                event_count: first.events.len() + second.events.len(),
+                text_preview: format!(
+                    "write={} read={} uncached={}",
+                    first_usage.cache_write, second_usage.cache_read, second_usage.input
+                ),
+                tool_call_count: 0,
+                stop_reason: second.stop_reason.map(|r| format!("{r:?}")),
                 error: None,
             };
             write_result_artifact(&vr);


### PR DESCRIPTION
Cache the system prompt and tool definitions. Both are byte-identical every turn and were re-billed at full input rate; now turns after the first read them at ~0.1x.

Two breakpoints: system block, and the final tool (Anthropic caches everything before a marked block, so one marker covers the whole tools array). `system` moves from a bare string to typed blocks — required to carry `cache_control`.

`CacheRetention::Long` uses the 1h TTL only on `api.anthropic.com`; relays reject `ttl`, so it degrades to 5m there. The `extended-cache-ttl` beta flag is derived from the same helper that builds the body, so header and body can't drift apart.

## Unit tests

`cargo test --lib providers::anthropic` — 44 pass. Four new:

| Test | Pins |
|---|---|
| `marks_cache_breakpoints_when_retention_short` | Marker on system + **last** tool only, and that it survives serialization |
| `emits_no_cache_control_when_retention_none` | Opting out emits zero markers (writes cost 1.25x — marking uninvited overcharges) |
| `long_retention_sets_one_hour_ttl_only_on_first_party_base_url` | `ttl` dropped for relays, which 400 on it |
| `extended_cache_ttl_beta_flag_tracks_emitted_ttl` | Flag and `ttl` field ship together |

The serialization assert matters most: a field that never reaches the wire caches nothing and raises no error.

## Manual test

`PI_LIVE_PROVIDER_TESTS=1 cargo test --test provider_live_verify anthropic::` — 4 pass.

New `live_prompt_cache_writes_then_reads` hits the real API and covers what unit tests can't — that Anthropic accepts the shape and acts on it. Drives `build_request` → beta header → HTTP → SSE parse → usage.

```
call 1:  cache_write=2007  cache_read=0     input=332
call 2:  cache_write=0     cache_read=2007  input=332
```

Verified it fails. With caching off:

```
first call neither wrote nor read cache (write=0, read=0, input=10179)
```

Cost at those counts — cached prefix $0.000602 vs $0.006021 uncached (10x). Measured with a throwaway assertion, not committed: it would test the pricing table, not the caching.

## Second commit

`fix(tools)` is a prerequisite — `rustix::fs::Stat` and `std::os::unix::fs::MetadataExt` disagree on integer widths (macOS `st_mode` is `u16`, `st_dev` is `i32`). Crate doesn't compile on macOS without it.