### PR TITLE
feat(compaction): report post-compaction token estimates

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1330,6 +1330,23 @@ impl Agent {
         }
     }
 
+    /// Estimate the context that the next provider request will see after a
+    /// compaction has replaced older history with a summary.
+    pub(crate) fn estimate_post_compaction_tokens(&self, messages: &[Message]) -> u64 {
+        let system_bytes = self.config.system_prompt.as_deref().map_or(0, str::len);
+        let tool_bytes = self.tools.tools().iter().fold(0_usize, |total, tool| {
+            total
+                .saturating_add(tool.name().len())
+                .saturating_add(tool.description().len())
+                .saturating_add(
+                    serde_json::to_vec(&tool.parameters()).map_or(0, |schema| schema.len()),
+                )
+        });
+        compaction::estimate_model_messages_tokens_heuristic(messages).saturating_add(
+            compaction::estimate_text_tokens(system_bytes.saturating_add(tool_bytes)),
+        )
+    }
+
     /// Run the agent with a user message.
     ///
     /// Returns a stream of events and the final assistant message.
@@ -8747,26 +8764,27 @@ impl AgentSession {
             }
 
             if let Some(compaction) = before_outcome.compaction {
-                let result_value = Some(Self::auto_compaction_result_payload(
-                    compaction.summary.clone(),
-                    compaction.first_kept_entry_id.clone(),
-                    compaction.tokens_before,
-                    compaction.details.clone(),
-                ));
                 self.extensions_is_compacting
                     .store(true, std::sync::atomic::Ordering::SeqCst);
                 let apply_result = self
                     .apply_compaction_entry(
-                        compaction.summary,
-                        compaction.first_kept_entry_id,
+                        compaction.summary.clone(),
+                        compaction.first_kept_entry_id.clone(),
                         compaction.tokens_before,
-                        compaction.details,
+                        compaction.details.clone(),
                         true,
                     )
                     .await;
                 self.extensions_is_compacting
                     .store(false, std::sync::atomic::Ordering::SeqCst);
-                apply_result?;
+                let tokens_after = apply_result?;
+                let result_value = Some(Self::auto_compaction_result_payload(
+                    compaction.summary,
+                    compaction.first_kept_entry_id,
+                    compaction.tokens_before,
+                    tokens_after,
+                    compaction.details,
+                ));
                 on_event(AgentEvent::AutoCompactionEnd {
                     result: result_value,
                     aborted: false,
@@ -8888,6 +8906,7 @@ impl AgentSession {
         summary: String,
         first_kept_entry_id: String,
         tokens_before: u64,
+        tokens_after: u64,
         details: Option<Value>,
     ) -> Value {
         let mut payload = serde_json::Map::new();
@@ -8897,6 +8916,7 @@ impl AgentSession {
             Value::String(first_kept_entry_id),
         );
         payload.insert("tokensBefore".to_string(), Value::from(tokens_before));
+        payload.insert("tokensAfter".to_string(), Value::from(tokens_after));
         if let Some(details) = details {
             payload.insert("details".to_string(), details);
         }
@@ -8910,7 +8930,7 @@ impl AgentSession {
         tokens_before: u64,
         details: Option<Value>,
         from_extension: bool,
-    ) -> Result<()> {
+    ) -> Result<u64> {
         let cx = crate::agent_cx::AgentCx::for_request();
         let mut session = OwnedMutexGuard::lock(Arc::clone(&self.session), cx.cx())
             .await
@@ -8938,6 +8958,8 @@ impl AgentSession {
                 None
             }
         });
+        let messages = session.to_messages_for_current_path();
+        let tokens_after = self.agent.estimate_post_compaction_tokens(&messages);
         drop(session);
 
         if let (Some(region), Some(compaction_entry)) = (&self.extensions, compaction_entry) {
@@ -8954,7 +8976,7 @@ impl AgentSession {
             }
         }
 
-        Ok(())
+        Ok(tokens_after)
     }
 
     /// Apply a completed compaction result to the session.
@@ -8964,21 +8986,22 @@ impl AgentSession {
         on_event: AgentEventHandler,
     ) -> Result<()> {
         let details = Some(compaction::compaction_details_to_value(&result.details)?);
+        let tokens_after = self
+            .apply_compaction_entry(
+                result.summary.clone(),
+                result.first_kept_entry_id.clone(),
+                result.tokens_before,
+                details.clone(),
+                false,
+            )
+            .await?;
         let result_value = Some(Self::auto_compaction_result_payload(
-            result.summary.clone(),
-            result.first_kept_entry_id.clone(),
-            result.tokens_before,
-            details.clone(),
-        ));
-
-        self.apply_compaction_entry(
             result.summary,
             result.first_kept_entry_id,
             result.tokens_before,
+            tokens_after,
             details,
-            false,
-        )
-        .await?;
+        ));
 
         on_event(AgentEvent::AutoCompactionEnd {
             result: result_value,
@@ -9030,26 +9053,27 @@ impl AgentSession {
             }
 
             if let Some(compaction) = before_outcome.compaction {
-                let result_value = Some(Self::auto_compaction_result_payload(
-                    compaction.summary.clone(),
-                    compaction.first_kept_entry_id.clone(),
-                    compaction.tokens_before,
-                    compaction.details.clone(),
-                ));
                 self.extensions_is_compacting
                     .store(true, std::sync::atomic::Ordering::SeqCst);
                 let apply_result = self
                     .apply_compaction_entry(
-                        compaction.summary,
-                        compaction.first_kept_entry_id,
+                        compaction.summary.clone(),
+                        compaction.first_kept_entry_id.clone(),
                         compaction.tokens_before,
-                        compaction.details,
+                        compaction.details.clone(),
                         true,
                     )
                     .await;
                 self.extensions_is_compacting
                     .store(false, std::sync::atomic::Ordering::SeqCst);
-                apply_result?;
+                let tokens_after = apply_result?;
+                let result_value = Some(Self::auto_compaction_result_payload(
+                    compaction.summary,
+                    compaction.first_kept_entry_id,
+                    compaction.tokens_before,
+                    tokens_after,
+                    compaction.details,
+                ));
                 on_event(AgentEvent::AutoCompactionEnd {
                     result: result_value,
                     aborted: false,
@@ -12859,6 +12883,7 @@ mod tests {
                 "summary": "Compacted",
                 "firstKeptEntryId": "abc123",
                 "tokensBefore": 50000,
+                "tokensAfter": 12000,
                 "details": { "readFiles": [], "modifiedFiles": [] }
             })),
             aborted: false,
@@ -12940,6 +12965,11 @@ mod tests {
             assert_eq!(payload["summary"], "Compacted 10 messages into 2");
             assert_eq!(payload["firstKeptEntryId"], "entry-5");
             assert_eq!(payload["tokensBefore"], 12_000);
+            assert!(
+                payload["tokensAfter"]
+                    .as_u64()
+                    .is_some_and(|tokens| tokens > 0)
+            );
             assert_eq!(payload["details"]["readFiles"], json!(["src/main.rs"]));
             assert_eq!(payload["details"]["modifiedFiles"], json!(["src/agent.rs"]));
         });

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -814,6 +814,27 @@ fn estimate_context_tokens(messages: &[SessionMessage]) -> ContextUsageEstimate 
     }
 }
 
+/// Estimate a complete model-message list without trusting provider usage
+/// attached to retained assistant messages. After compaction those usage totals
+/// still describe the pre-compaction request, so they would overstate the new
+/// active context.
+#[must_use]
+pub(crate) fn estimate_model_messages_tokens_heuristic(messages: &[Message]) -> u64 {
+    messages
+        .iter()
+        .cloned()
+        .map(SessionMessage::from)
+        .map(|message| estimate_tokens(&message))
+        .fold(0_u64, u64::saturating_add)
+}
+
+/// Estimate plain text or serialized schema overhead using the same heuristic
+/// as session message estimation.
+#[must_use]
+pub(crate) fn estimate_text_tokens(text_bytes: usize) -> u64 {
+    u64::try_from(text_bytes.div_ceil(CHARS_PER_TOKEN_ESTIMATE)).unwrap_or(u64::MAX)
+}
+
 fn should_compact(
     context_tokens: u64,
     context_window: u32,
@@ -2755,6 +2776,18 @@ mod tests {
         // "hi" => 1, "hello" => 2, "bye" => 1.
         assert_eq!(estimate.tokens, 4);
         assert!(estimate.last_usage_index.is_none());
+    }
+
+    #[test]
+    fn post_compaction_estimate_ignores_stale_provider_usage() {
+        let messages = vec![
+            session_message_to_model(&make_user_text("hi")).expect("user message"),
+            session_message_to_model(&make_assistant_text("hello", 50_000, 10_000))
+                .expect("assistant message"),
+            session_message_to_model(&make_user_text("bye")).expect("user message"),
+        ];
+
+        assert_eq!(estimate_model_messages_tokens_heuristic(&messages), 4);
     }
 
     // ── extract_file_ops_from_message ────────────────────────────────

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -822,9 +822,7 @@ fn estimate_context_tokens(messages: &[SessionMessage]) -> ContextUsageEstimate 
 pub(crate) fn estimate_model_messages_tokens_heuristic(messages: &[Message]) -> u64 {
     messages
         .iter()
-        .cloned()
-        .map(SessionMessage::from)
-        .map(|message| estimate_tokens(&message))
+        .map(estimate_tokens)
         .fold(0_u64, u64::saturating_add)
 }
 
@@ -848,85 +846,66 @@ fn should_compact(
     context_tokens >= window.saturating_sub(reserve)
 }
 
-fn estimate_tokens(message: &SessionMessage) -> u64 {
-    let mut chars: usize = 0;
+trait TokenEstimable {
+    fn estimated_chars(&self) -> usize;
+}
 
-    match message {
-        SessionMessage::User { content, .. } => match content {
-            UserContent::Text(text) => chars = text.len(),
-            UserContent::Blocks(blocks) => {
-                for block in blocks {
-                    match block {
-                        ContentBlock::Text(text) => {
-                            chars = chars.saturating_add(text.text.len());
-                        }
-                        ContentBlock::Image(_) => {
-                            chars = chars.saturating_add(IMAGE_CHAR_ESTIMATE);
-                        }
-                        ContentBlock::Thinking(thinking) => {
-                            chars = chars.saturating_add(thinking.thinking.len());
-                        }
-                        ContentBlock::ToolCall(call) => {
-                            chars = chars.saturating_add(call.name.len());
-                            chars = chars.saturating_add(json_byte_len(&call.arguments));
-                        }
-                        // Opaque marker — the data field is never replayed to a model
-                        // (see `convert_content_block_to_anthropic`), so it contributes
-                        // zero context tokens.
-                        ContentBlock::RedactedThinking(_) => {}
-                    }
-                }
-            }
-        },
-        SessionMessage::Assistant { message } => {
-            for block in &message.content {
-                match block {
-                    ContentBlock::Text(text) => {
-                        chars = chars.saturating_add(text.text.len());
-                    }
-                    ContentBlock::Thinking(thinking) => {
-                        chars = chars.saturating_add(thinking.thinking.len());
-                    }
-                    ContentBlock::Image(_) => {
-                        chars = chars.saturating_add(IMAGE_CHAR_ESTIMATE);
-                    }
-                    ContentBlock::ToolCall(call) => {
-                        chars = chars.saturating_add(call.name.len());
-                        chars = chars.saturating_add(json_byte_len(&call.arguments));
-                    }
-                    ContentBlock::RedactedThinking(_) => {}
-                }
-            }
+fn estimate_tokens(message: &impl TokenEstimable) -> u64 {
+    u64::try_from(message.estimated_chars().div_ceil(CHARS_PER_TOKEN_ESTIMATE)).unwrap_or(u64::MAX)
+}
+
+fn estimate_content_blocks_chars(blocks: &[ContentBlock]) -> usize {
+    blocks.iter().fold(0_usize, |chars, block| {
+        let block_chars = match block {
+            ContentBlock::Text(text) => text.text.len(),
+            ContentBlock::Thinking(thinking) => thinking.thinking.len(),
+            ContentBlock::Image(_) => IMAGE_CHAR_ESTIMATE,
+            ContentBlock::ToolCall(call) => call
+                .name
+                .len()
+                .saturating_add(json_byte_len(&call.arguments)),
+            // Opaque marker — the data field is never replayed to a model
+            // (see `convert_content_block_to_anthropic`), so it contributes
+            // zero context tokens.
+            ContentBlock::RedactedThinking(_) => 0,
+        };
+        chars.saturating_add(block_chars)
+    })
+}
+
+impl TokenEstimable for Message {
+    fn estimated_chars(&self) -> usize {
+        match self {
+            Message::User(user) => match &user.content {
+                UserContent::Text(text) => text.len(),
+                UserContent::Blocks(blocks) => estimate_content_blocks_chars(blocks),
+            },
+            Message::Assistant(message) => estimate_content_blocks_chars(&message.content),
+            Message::ToolResult(message) => estimate_content_blocks_chars(&message.content),
+            Message::Custom(message) => message.content.len(),
         }
-        SessionMessage::ToolResult { content, .. } => {
-            for block in content {
-                match block {
-                    ContentBlock::Text(text) => {
-                        chars = chars.saturating_add(text.text.len());
-                    }
-                    ContentBlock::Thinking(thinking) => {
-                        chars = chars.saturating_add(thinking.thinking.len());
-                    }
-                    ContentBlock::Image(_) => {
-                        chars = chars.saturating_add(IMAGE_CHAR_ESTIMATE);
-                    }
-                    ContentBlock::ToolCall(call) => {
-                        chars = chars.saturating_add(call.name.len());
-                        chars = chars.saturating_add(json_byte_len(&call.arguments));
-                    }
-                    ContentBlock::RedactedThinking(_) => {}
-                }
-            }
-        }
-        SessionMessage::Custom { content, .. } => chars = content.len(),
-        SessionMessage::BashExecution {
-            command, output, ..
-        } => chars = command.len().saturating_add(output.len()),
-        SessionMessage::BranchSummary { summary, .. }
-        | SessionMessage::CompactionSummary { summary, .. } => chars = summary.len(),
     }
+}
 
-    u64::try_from(chars.div_ceil(CHARS_PER_TOKEN_ESTIMATE)).unwrap_or(u64::MAX)
+impl TokenEstimable for SessionMessage {
+    fn estimated_chars(&self) -> usize {
+        match self {
+            SessionMessage::User { content, .. } => match content {
+                UserContent::Text(text) => text.len(),
+                UserContent::Blocks(blocks) => estimate_content_blocks_chars(blocks),
+            },
+            SessionMessage::Assistant { message } => {
+                estimate_content_blocks_chars(&message.content)
+            }
+            SessionMessage::ToolResult { content, .. } => estimate_content_blocks_chars(content),
+            SessionMessage::Custom { content, .. } => content.len(),
+            SessionMessage::BashExecution {
+                command, output, ..
+            } => command.len().saturating_add(output.len()),
+            SessionMessage::BranchSummary { summary, .. }
+            | SessionMessage::CompactionSummary { summary, .. } => summary.len(),
+        }
+    }
 }
 
 // =============================================================================

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1757,6 +1757,7 @@ pub async fn run(
                         );
                         inner_session.to_messages_for_current_path()
                     };
+                    let tokens_after = guard.agent.estimate_post_compaction_tokens(&messages);
                     guard.persist_session().await?;
                     guard.agent.replace_messages(messages);
 
@@ -1764,6 +1765,7 @@ pub async fn run(
                         "summary": result_data.summary,
                         "firstKeptEntryId": result_data.first_kept_entry_id,
                         "tokensBefore": result_data.tokens_before,
+                        "tokensAfter": tokens_after,
                         "details": details_value,
                     }))
                 }
@@ -4174,6 +4176,7 @@ async fn maybe_auto_compact(
                 );
                 inner_session.to_messages_for_current_path()
             };
+            let tokens_after = guard.agent.estimate_post_compaction_tokens(&messages);
             let _ = guard.persist_session().await;
             guard.agent.replace_messages(messages);
             drop(guard);
@@ -4183,6 +4186,7 @@ async fn maybe_auto_compact(
                     "summary": result.summary,
                     "firstKeptEntryId": result.first_kept_entry_id,
                     "tokensBefore": result.tokens_before,
+                    "tokensAfter": tokens_after,
                     "details": details_value,
                 })),
                 aborted: false,

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -606,6 +606,7 @@ pub struct RpcCompactionResult {
     pub summary: String,
     pub first_kept_entry_id: String,
     pub tokens_before: u64,
+    pub tokens_after: u64,
     #[serde(default)]
     pub details: Value,
 }

--- a/tests/sdk_unit.rs
+++ b/tests/sdk_unit.rs
@@ -606,12 +606,14 @@ fn rpc_compaction_result_serde() {
         "summary": "Compacted 10 messages into 2",
         "firstKeptEntryId": "entry-5",
         "tokensBefore": 12000,
+        "tokensAfter": 3200,
         "details": {"removed": 8}
     });
     let result: RpcCompactionResult = serde_json::from_value(value.clone()).expect("deserialize");
     assert_eq!(result.summary, "Compacted 10 messages into 2");
     assert_eq!(result.first_kept_entry_id, "entry-5");
     assert_eq!(result.tokens_before, 12000);
+    assert_eq!(result.tokens_after, 3200);
 
     let reencoded = serde_json::to_value(&result).expect("serialize");
     assert_eq!(reencoded, value);
@@ -623,6 +625,7 @@ fn rpc_compaction_result_serde() {
                 "tokens_before".to_string(),
                 result.tokens_before.to_string(),
             ));
+            ctx.push(("tokens_after".to_string(), result.tokens_after.to_string()));
         });
 }
 


### PR DESCRIPTION
## Summary

This PR adds `tokensAfter` to compaction results, representing the estimated token count of the context that will be sent with the next provider request after compaction is applied.

- Calculates `tokensAfter` after the compacted session history has been written.
- Includes model messages, system prompt, and tool schema overhead.
- Exposes `tokensAfter` through manual compaction, RPC auto-compaction, and agent auto-compaction payloads.
- Extends `RpcCompactionResult` and its serde coverage.
- Refactors token estimation so model messages are estimated by reference, avoiding cloning the full post-compaction message list.
- Ignores retained assistant provider usage for `tokensAfter`, because that usage belongs to the pre-compaction provider request and would otherwise inflate the result.

## Definition of Done Evidence

### Unit Evidence

Passed:

```sh
rustfmt --edition 2024 --check `compaction.rs`
cargo test --lib compaction::tests::post_compaction_estimate_ignores_stale_provider_usage
```

The compaction test verifies that retained assistant messages with stale provider usage do not inflate the post-compaction estimate.

SDK serde coverage verifies that `tokensAfter` serializes and deserializes with `RpcCompactionResult`.

### E2E Evidence

Not run. This change is limited to compaction accounting and result payloads.

A broader test run is currently blocked by unrelated integration-test API drift in `tests/tui_state.rs` and `tests/capability_prompt.rs`, where `PiApp::new` is called with outdated arguments.

### Extension Evidence

Not run. This PR does not change extension behavior beyond the existing compaction result payload gaining a `tokensAfter` field.

## Reproduction Commands

```sh
rustfmt --edition 2024 --check `compaction.rs`
cargo test --lib compaction::tests::post_compaction_estimate_ignores_stale_provider_usage
```

After manual or automatic compaction, the result payload now includes:

```json
{
  "tokensBefore": 50000,
  "tokensAfter": 12000
}
```

## Migration Guidance

Consumers may use `tokensAfter` to inspect the estimated token size of the active post-compaction context. Existing consumers that only read `tokensBefore` continue to work unchanged.
