### PR TITLE
fix(extensions): align plugin entry discovery with Pi manifest rules

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1330,6 +1330,23 @@ impl Agent {
         }
     }
 
+    /// Estimate the context that the next provider request will see after a
+    /// compaction has replaced older history with a summary.
+    pub(crate) fn estimate_post_compaction_tokens(&self, messages: &[Message]) -> u64 {
+        let system_bytes = self.config.system_prompt.as_deref().map_or(0, str::len);
+        let tool_bytes = self.tools.tools().iter().fold(0_usize, |total, tool| {
+            total
+                .saturating_add(tool.name().len())
+                .saturating_add(tool.description().len())
+                .saturating_add(
+                    serde_json::to_vec(&tool.parameters()).map_or(0, |schema| schema.len()),
+                )
+        });
+        compaction::estimate_model_messages_tokens_heuristic(messages).saturating_add(
+            compaction::estimate_text_tokens(system_bytes.saturating_add(tool_bytes)),
+        )
+    }
+
     /// Run the agent with a user message.
     ///
     /// Returns a stream of events and the final assistant message.
@@ -8747,26 +8764,27 @@ impl AgentSession {
             }
 
             if let Some(compaction) = before_outcome.compaction {
-                let result_value = Some(Self::auto_compaction_result_payload(
-                    compaction.summary.clone(),
-                    compaction.first_kept_entry_id.clone(),
-                    compaction.tokens_before,
-                    compaction.details.clone(),
-                ));
                 self.extensions_is_compacting
                     .store(true, std::sync::atomic::Ordering::SeqCst);
                 let apply_result = self
                     .apply_compaction_entry(
-                        compaction.summary,
-                        compaction.first_kept_entry_id,
+                        compaction.summary.clone(),
+                        compaction.first_kept_entry_id.clone(),
                         compaction.tokens_before,
-                        compaction.details,
+                        compaction.details.clone(),
                         true,
                     )
                     .await;
                 self.extensions_is_compacting
                     .store(false, std::sync::atomic::Ordering::SeqCst);
-                apply_result?;
+                let tokens_after = apply_result?;
+                let result_value = Some(Self::auto_compaction_result_payload(
+                    compaction.summary,
+                    compaction.first_kept_entry_id,
+                    compaction.tokens_before,
+                    tokens_after,
+                    compaction.details,
+                ));
                 on_event(AgentEvent::AutoCompactionEnd {
                     result: result_value,
                     aborted: false,
@@ -8888,6 +8906,7 @@ impl AgentSession {
         summary: String,
         first_kept_entry_id: String,
         tokens_before: u64,
+        tokens_after: u64,
         details: Option<Value>,
     ) -> Value {
         let mut payload = serde_json::Map::new();
@@ -8897,6 +8916,7 @@ impl AgentSession {
             Value::String(first_kept_entry_id),
         );
         payload.insert("tokensBefore".to_string(), Value::from(tokens_before));
+        payload.insert("tokensAfter".to_string(), Value::from(tokens_after));
         if let Some(details) = details {
             payload.insert("details".to_string(), details);
         }
@@ -8910,7 +8930,7 @@ impl AgentSession {
         tokens_before: u64,
         details: Option<Value>,
         from_extension: bool,
-    ) -> Result<()> {
+    ) -> Result<u64> {
         let cx = crate::agent_cx::AgentCx::for_request();
         let mut session = OwnedMutexGuard::lock(Arc::clone(&self.session), cx.cx())
             .await
@@ -8938,6 +8958,8 @@ impl AgentSession {
                 None
             }
         });
+        let messages = session.to_messages_for_current_path();
+        let tokens_after = self.agent.estimate_post_compaction_tokens(&messages);
         drop(session);
 
         if let (Some(region), Some(compaction_entry)) = (&self.extensions, compaction_entry) {
@@ -8954,7 +8976,7 @@ impl AgentSession {
             }
         }
 
-        Ok(())
+        Ok(tokens_after)
     }
 
     /// Apply a completed compaction result to the session.
@@ -8964,21 +8986,22 @@ impl AgentSession {
         on_event: AgentEventHandler,
     ) -> Result<()> {
         let details = Some(compaction::compaction_details_to_value(&result.details)?);
+        let tokens_after = self
+            .apply_compaction_entry(
+                result.summary.clone(),
+                result.first_kept_entry_id.clone(),
+                result.tokens_before,
+                details.clone(),
+                false,
+            )
+            .await?;
         let result_value = Some(Self::auto_compaction_result_payload(
-            result.summary.clone(),
-            result.first_kept_entry_id.clone(),
-            result.tokens_before,
-            details.clone(),
-        ));
-
-        self.apply_compaction_entry(
             result.summary,
             result.first_kept_entry_id,
             result.tokens_before,
+            tokens_after,
             details,
-            false,
-        )
-        .await?;
+        ));
 
         on_event(AgentEvent::AutoCompactionEnd {
             result: result_value,
@@ -9030,26 +9053,27 @@ impl AgentSession {
             }
 
             if let Some(compaction) = before_outcome.compaction {
-                let result_value = Some(Self::auto_compaction_result_payload(
-                    compaction.summary.clone(),
-                    compaction.first_kept_entry_id.clone(),
-                    compaction.tokens_before,
-                    compaction.details.clone(),
-                ));
                 self.extensions_is_compacting
                     .store(true, std::sync::atomic::Ordering::SeqCst);
                 let apply_result = self
                     .apply_compaction_entry(
-                        compaction.summary,
-                        compaction.first_kept_entry_id,
+                        compaction.summary.clone(),
+                        compaction.first_kept_entry_id.clone(),
                         compaction.tokens_before,
-                        compaction.details,
+                        compaction.details.clone(),
                         true,
                     )
                     .await;
                 self.extensions_is_compacting
                     .store(false, std::sync::atomic::Ordering::SeqCst);
-                apply_result?;
+                let tokens_after = apply_result?;
+                let result_value = Some(Self::auto_compaction_result_payload(
+                    compaction.summary,
+                    compaction.first_kept_entry_id,
+                    compaction.tokens_before,
+                    tokens_after,
+                    compaction.details,
+                ));
                 on_event(AgentEvent::AutoCompactionEnd {
                     result: result_value,
                     aborted: false,
@@ -12859,6 +12883,7 @@ mod tests {
                 "summary": "Compacted",
                 "firstKeptEntryId": "abc123",
                 "tokensBefore": 50000,
+                "tokensAfter": 12000,
                 "details": { "readFiles": [], "modifiedFiles": [] }
             })),
             aborted: false,
@@ -12940,6 +12965,11 @@ mod tests {
             assert_eq!(payload["summary"], "Compacted 10 messages into 2");
             assert_eq!(payload["firstKeptEntryId"], "entry-5");
             assert_eq!(payload["tokensBefore"], 12_000);
+            assert!(
+                payload["tokensAfter"]
+                    .as_u64()
+                    .is_some_and(|tokens| tokens > 0)
+            );
             assert_eq!(payload["details"]["readFiles"], json!(["src/main.rs"]));
             assert_eq!(payload["details"]["modifiedFiles"], json!(["src/agent.rs"]));
         });

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -814,6 +814,27 @@ fn estimate_context_tokens(messages: &[SessionMessage]) -> ContextUsageEstimate 
     }
 }
 
+/// Estimate a complete model-message list without trusting provider usage
+/// attached to retained assistant messages. After compaction those usage totals
+/// still describe the pre-compaction request, so they would overstate the new
+/// active context.
+#[must_use]
+pub(crate) fn estimate_model_messages_tokens_heuristic(messages: &[Message]) -> u64 {
+    messages
+        .iter()
+        .cloned()
+        .map(SessionMessage::from)
+        .map(|message| estimate_tokens(&message))
+        .fold(0_u64, u64::saturating_add)
+}
+
+/// Estimate plain text or serialized schema overhead using the same heuristic
+/// as session message estimation.
+#[must_use]
+pub(crate) fn estimate_text_tokens(text_bytes: usize) -> u64 {
+    u64::try_from(text_bytes.div_ceil(CHARS_PER_TOKEN_ESTIMATE)).unwrap_or(u64::MAX)
+}
+
 fn should_compact(
     context_tokens: u64,
     context_window: u32,
@@ -2755,6 +2776,18 @@ mod tests {
         // "hi" => 1, "hello" => 2, "bye" => 1.
         assert_eq!(estimate.tokens, 4);
         assert!(estimate.last_usage_index.is_none());
+    }
+
+    #[test]
+    fn post_compaction_estimate_ignores_stale_provider_usage() {
+        let messages = vec![
+            session_message_to_model(&make_user_text("hi")).expect("user message"),
+            session_message_to_model(&make_assistant_text("hello", 50_000, 10_000))
+                .expect("assistant message"),
+            session_message_to_model(&make_user_text("bye")).expect("user message"),
+        ];
+
+        assert_eq!(estimate_model_messages_tokens_heuristic(&messages), 4);
     }
 
     // ── extract_file_ops_from_message ────────────────────────────────

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -822,9 +822,7 @@ fn estimate_context_tokens(messages: &[SessionMessage]) -> ContextUsageEstimate 
 pub(crate) fn estimate_model_messages_tokens_heuristic(messages: &[Message]) -> u64 {
     messages
         .iter()
-        .cloned()
-        .map(SessionMessage::from)
-        .map(|message| estimate_tokens(&message))
+        .map(estimate_tokens)
         .fold(0_u64, u64::saturating_add)
 }
 
@@ -848,85 +846,66 @@ fn should_compact(
     context_tokens >= window.saturating_sub(reserve)
 }
 
-fn estimate_tokens(message: &SessionMessage) -> u64 {
-    let mut chars: usize = 0;
+trait TokenEstimable {
+    fn estimated_chars(&self) -> usize;
+}
 
-    match message {
-        SessionMessage::User { content, .. } => match content {
-            UserContent::Text(text) => chars = text.len(),
-            UserContent::Blocks(blocks) => {
-                for block in blocks {
-                    match block {
-                        ContentBlock::Text(text) => {
-                            chars = chars.saturating_add(text.text.len());
-                        }
-                        ContentBlock::Image(_) => {
-                            chars = chars.saturating_add(IMAGE_CHAR_ESTIMATE);
-                        }
-                        ContentBlock::Thinking(thinking) => {
-                            chars = chars.saturating_add(thinking.thinking.len());
-                        }
-                        ContentBlock::ToolCall(call) => {
-                            chars = chars.saturating_add(call.name.len());
-                            chars = chars.saturating_add(json_byte_len(&call.arguments));
-                        }
-                        // Opaque marker — the data field is never replayed to a model
-                        // (see `convert_content_block_to_anthropic`), so it contributes
-                        // zero context tokens.
-                        ContentBlock::RedactedThinking(_) => {}
-                    }
-                }
-            }
-        },
-        SessionMessage::Assistant { message } => {
-            for block in &message.content {
-                match block {
-                    ContentBlock::Text(text) => {
-                        chars = chars.saturating_add(text.text.len());
-                    }
-                    ContentBlock::Thinking(thinking) => {
-                        chars = chars.saturating_add(thinking.thinking.len());
-                    }
-                    ContentBlock::Image(_) => {
-                        chars = chars.saturating_add(IMAGE_CHAR_ESTIMATE);
-                    }
-                    ContentBlock::ToolCall(call) => {
-                        chars = chars.saturating_add(call.name.len());
-                        chars = chars.saturating_add(json_byte_len(&call.arguments));
-                    }
-                    ContentBlock::RedactedThinking(_) => {}
-                }
-            }
+fn estimate_tokens(message: &impl TokenEstimable) -> u64 {
+    u64::try_from(message.estimated_chars().div_ceil(CHARS_PER_TOKEN_ESTIMATE)).unwrap_or(u64::MAX)
+}
+
+fn estimate_content_blocks_chars(blocks: &[ContentBlock]) -> usize {
+    blocks.iter().fold(0_usize, |chars, block| {
+        let block_chars = match block {
+            ContentBlock::Text(text) => text.text.len(),
+            ContentBlock::Thinking(thinking) => thinking.thinking.len(),
+            ContentBlock::Image(_) => IMAGE_CHAR_ESTIMATE,
+            ContentBlock::ToolCall(call) => call
+                .name
+                .len()
+                .saturating_add(json_byte_len(&call.arguments)),
+            // Opaque marker — the data field is never replayed to a model
+            // (see `convert_content_block_to_anthropic`), so it contributes
+            // zero context tokens.
+            ContentBlock::RedactedThinking(_) => 0,
+        };
+        chars.saturating_add(block_chars)
+    })
+}
+
+impl TokenEstimable for Message {
+    fn estimated_chars(&self) -> usize {
+        match self {
+            Message::User(user) => match &user.content {
+                UserContent::Text(text) => text.len(),
+                UserContent::Blocks(blocks) => estimate_content_blocks_chars(blocks),
+            },
+            Message::Assistant(message) => estimate_content_blocks_chars(&message.content),
+            Message::ToolResult(message) => estimate_content_blocks_chars(&message.content),
+            Message::Custom(message) => message.content.len(),
         }
-        SessionMessage::ToolResult { content, .. } => {
-            for block in content {
-                match block {
-                    ContentBlock::Text(text) => {
-                        chars = chars.saturating_add(text.text.len());
-                    }
-                    ContentBlock::Thinking(thinking) => {
-                        chars = chars.saturating_add(thinking.thinking.len());
-                    }
-                    ContentBlock::Image(_) => {
-                        chars = chars.saturating_add(IMAGE_CHAR_ESTIMATE);
-                    }
-                    ContentBlock::ToolCall(call) => {
-                        chars = chars.saturating_add(call.name.len());
-                        chars = chars.saturating_add(json_byte_len(&call.arguments));
-                    }
-                    ContentBlock::RedactedThinking(_) => {}
-                }
-            }
-        }
-        SessionMessage::Custom { content, .. } => chars = content.len(),
-        SessionMessage::BashExecution {
-            command, output, ..
-        } => chars = command.len().saturating_add(output.len()),
-        SessionMessage::BranchSummary { summary, .. }
-        | SessionMessage::CompactionSummary { summary, .. } => chars = summary.len(),
     }
+}
 
-    u64::try_from(chars.div_ceil(CHARS_PER_TOKEN_ESTIMATE)).unwrap_or(u64::MAX)
+impl TokenEstimable for SessionMessage {
+    fn estimated_chars(&self) -> usize {
+        match self {
+            SessionMessage::User { content, .. } => match content {
+                UserContent::Text(text) => text.len(),
+                UserContent::Blocks(blocks) => estimate_content_blocks_chars(blocks),
+            },
+            SessionMessage::Assistant { message } => {
+                estimate_content_blocks_chars(&message.content)
+            }
+            SessionMessage::ToolResult { content, .. } => estimate_content_blocks_chars(content),
+            SessionMessage::Custom { content, .. } => content.len(),
+            SessionMessage::BashExecution {
+                command, output, ..
+            } => command.len().saturating_add(output.len()),
+            SessionMessage::BranchSummary { summary, .. }
+            | SessionMessage::CompactionSummary { summary, .. } => summary.len(),
+        }
+    }
 }
 
 // =============================================================================

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -12596,9 +12596,6 @@ pub type NativeRustExtensionRuntimeHandle =
     native_runtime_duplicate_scaffold::NativeRustExtensionRuntimeHandle;
 
 const JS_EXTENSION_ENTRY_EXTS: &[&str] = &["ts", "tsx", "jsx", "js", "mjs", "cjs", "mts", "cts"];
-const MAX_BUNDLE_CLUSTER_DIRS: usize = 40;
-const MAX_AUXILIARY_EXAMPLE_ENTRIES: usize = 24;
-const AUXILIARY_EXTENSION_DIR_NAMES: &[&str] = &["examples", "example", "demos", "demo"];
 
 fn is_supported_js_extension_entry(path: &Path) -> bool {
     path.extension()
@@ -12705,133 +12702,6 @@ fn collect_extension_entries_from_dir(dir: &Path) -> Vec<PathBuf> {
     out
 }
 
-fn is_likely_auxiliary_extension_entry(path: &Path) -> bool {
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    if file_name.contains("extension")
-        || file_name.contains("plugin")
-        || file_name.contains("command")
-    {
-        return true;
-    }
-
-    let Ok(raw) = fs::read(path) else {
-        return false;
-    };
-    let preview_len = raw.len().min(32_768);
-    let preview = String::from_utf8_lossy(&raw[..preview_len]);
-    [
-        "registerCommand(",
-        "registerTool(",
-        "registerProvider(",
-        "registerShortcut(",
-        "registerFlag(",
-        "pi.registerCommand(",
-        "pi.registerTool(",
-        "pi.registerProvider(",
-        "export default function",
-    ]
-    .iter()
-    .any(|needle| preview.contains(needle))
-}
-
-fn is_likely_flat_extension_entry(path: &Path) -> bool {
-    let Ok(raw) = fs::read(path) else {
-        return false;
-    };
-    let preview_len = raw.len().min(32_768);
-    let preview = String::from_utf8_lossy(&raw[..preview_len]);
-
-    let has_default_initializer = [
-        "export default function",
-        "export default async function",
-        "export default(",
-        "export default (",
-        "export default async(",
-        "export default async (",
-    ]
-    .iter()
-    .any(|needle| preview.contains(needle));
-
-    let has_named_initializer = named_flat_extension_initializer_regex().is_match(&preview);
-    let has_default_object_initializer =
-        default_object_flat_extension_initializer_regex().is_match(&preview);
-
-    let has_registration = [
-        "registerCommand(",
-        "registerTool(",
-        "registerProvider(",
-        "registerShortcut(",
-        "registerFlag(",
-        "pi.registerCommand(",
-        "pi.registerTool(",
-        "pi.registerProvider(",
-        "pi.registerShortcut(",
-        "pi.registerFlag(",
-    ]
-    .iter()
-    .any(|needle| preview.contains(needle));
-
-    has_default_initializer
-        || has_named_initializer
-        || has_default_object_initializer
-        || has_registration
-}
-
-const FLAT_EXTENSION_INITIALIZER_NAMES: &str =
-    r"(?:activate|init(?:ialize)?|setup|register|plugin|main)";
-
-fn named_flat_extension_initializer_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(&format!(
-            r"(?m)\bexport\s+(?:async\s+)?function\s+{FLAT_EXTENSION_INITIALIZER_NAMES}\b|\bexport\s+(?:const|let|var)\s+{FLAT_EXTENSION_INITIALIZER_NAMES}\s*=\s*(?:async\s+)?(?:function\b|\([^)]*\)\s*=>|[A-Za-z_$][\w$]*\s*=>)"
-        ))
-        .expect("named flat extension initializer regex")
-    })
-}
-
-fn default_object_flat_extension_initializer_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(&format!(
-            r#"(?ms)\bexport\s+default\s*\{{.*?(?:\b(?:async\s+)?{FLAT_EXTENSION_INITIALIZER_NAMES}\s*\(|\b{FLAT_EXTENSION_INITIALIZER_NAMES}\s*:\s*(?:async\s+)?(?:function\b|\([^)]*\)\s*=>|[A-Za-z_$][\w$]*\s*=>)|["'`]{FLAT_EXTENSION_INITIALIZER_NAMES}["'`]\s*(?:\(|:\s*(?:async\s+)?(?:function\b|\([^)]*\)\s*=>|[A-Za-z_$][\w$]*\s*=>)))"#
-        ))
-        .expect("default object flat extension initializer regex")
-    })
-}
-
-fn discover_auxiliary_example_entries(
-    package_dir: &Path,
-    canonical_primary: &Path,
-) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    let mut seen = BTreeSet::new();
-
-    for dir_name in AUXILIARY_EXTENSION_DIR_NAMES {
-        let candidate_dir = package_dir.join(dir_name);
-        for candidate in collect_extension_entries_from_dir(&candidate_dir) {
-            if candidate == canonical_primary {
-                continue;
-            }
-            if !is_likely_auxiliary_extension_entry(&candidate) {
-                continue;
-            }
-            if seen.insert(candidate.clone()) {
-                out.push(candidate);
-                if out.len() >= MAX_AUXILIARY_EXAMPLE_ENTRIES {
-                    return out;
-                }
-            }
-        }
-    }
-
-    out
-}
-
 fn read_pi_extensions_from_package(package_json_path: &Path) -> Result<Option<Vec<String>>> {
     if !package_json_path.is_file() {
         return Ok(None);
@@ -12900,16 +12770,6 @@ fn read_pi_extensions_from_package(package_json_path: &Path) -> Result<Option<Ve
     }
 }
 
-fn parse_package_name_from_package(package_json_path: &Path) -> Option<String> {
-    let raw = fs::read_to_string(package_json_path).ok()?;
-    let json = serde_json::from_str::<Value>(&raw).ok()?;
-    json.get("name")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|name| !name.is_empty())
-        .map(ToOwned::to_owned)
-}
-
 fn find_package_json_ancestors(mut dir: Option<&Path>) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let mut seen = BTreeSet::new();
@@ -12950,48 +12810,12 @@ fn collect_extension_roots_from_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
     roots
 }
 
-fn extract_node_modules_package_name(entry: &str) -> Option<String> {
-    let normalized = entry.replace('\\', "/");
-    let marker = "node_modules/";
-    let start = normalized.find(marker)?;
-    let mut parts = normalized[start + marker.len()..].split('/');
-    let first = parts.next()?;
-    if first.starts_with('@') {
-        let second = parts.next()?;
-        Some(format!("{first}/{second}"))
-    } else {
-        Some(first.to_string())
-    }
-}
-
-fn find_workspace_package_dir_by_name(
-    workspace_root: &Path,
-    package_name: &str,
-) -> Option<PathBuf> {
-    let entries = fs::read_dir(workspace_root).ok()?;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        let package_json = path.join("package.json");
-        if !package_json.is_file() {
-            continue;
-        }
-        if parse_package_name_from_package(&package_json).is_some_and(|name| name == package_name) {
-            return Some(path);
-        }
-    }
-    None
-}
-
 fn resolve_package_declared_entries(
     package_dir: &Path,
     package_entries: &[String],
 ) -> Result<Vec<PathBuf>> {
     let mut out = Vec::new();
     let mut seen = BTreeSet::new();
-    let workspace_root = package_dir.parent();
 
     for raw_entry in package_entries {
         let mut resolved = Vec::new();
@@ -13002,32 +12826,6 @@ fn resolve_package_declared_entries(
             resolved.push(path);
         }
 
-        if resolved.is_empty()
-            && raw_entry.contains("node_modules/")
-            && let Some(workspace_root) = workspace_root
-            && let Some(package_name) = extract_node_modules_package_name(raw_entry)
-            && let Some(workspace_package_dir) =
-                find_workspace_package_dir_by_name(workspace_root, &package_name)
-        {
-            let nested_package_json = workspace_package_dir.join("package.json");
-            match read_pi_extensions_from_package(&nested_package_json)? {
-                Some(nested_entries) if !nested_entries.is_empty() => {
-                    resolved.extend(resolve_package_declared_entries(
-                        &workspace_package_dir,
-                        &nested_entries,
-                    )?);
-                }
-                Some(_) => {}
-                None => {
-                    if let Some(index_path) =
-                        resolve_extension_entry_file(&workspace_package_dir.join("index"))
-                    {
-                        resolved.push(index_path);
-                    }
-                }
-            }
-        }
-
         for path in resolved {
             if seen.insert(path.clone()) {
                 out.push(path);
@@ -13035,70 +12833,6 @@ fn resolve_package_declared_entries(
         }
     }
 
-    Ok(out)
-}
-
-fn discover_workspace_bundle_entries(package_dir: &Path) -> Result<Vec<PathBuf>> {
-    let Some(workspace_root) = package_dir.parent() else {
-        return Ok(Vec::new());
-    };
-
-    let mut cluster_dirs = Vec::new();
-    if let Ok(entries) = fs::read_dir(workspace_root) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                cluster_dirs.push(path);
-            }
-        }
-    }
-    if cluster_dirs.is_empty() || cluster_dirs.len() > MAX_BUNDLE_CLUSTER_DIRS {
-        return Ok(Vec::new());
-    }
-    cluster_dirs.sort();
-
-    let mut out = Vec::new();
-    let mut seen = BTreeSet::new();
-
-    for dir in &cluster_dirs {
-        let package_json = dir.join("package.json");
-        let Some(package_entries) = read_pi_extensions_from_package(&package_json)? else {
-            continue;
-        };
-        for path in resolve_package_declared_entries(dir, &package_entries)? {
-            if seen.insert(path.clone()) {
-                out.push(path);
-            }
-        }
-    }
-
-    let mut root_files = Vec::new();
-    if let Ok(entries) = fs::read_dir(workspace_root) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_file() && is_supported_js_extension_entry(&path) {
-                root_files.push(path);
-            }
-        }
-    }
-    root_files.sort();
-    for path in root_files {
-        let canonical = safe_canonicalize(&path);
-        if seen.insert(canonical.clone()) {
-            out.push(canonical);
-        }
-    }
-
-    for dir in cluster_dirs {
-        if dir.join("package.json").is_file() {
-            continue;
-        }
-        for path in collect_extension_entries_from_dir(&dir) {
-            if seen.insert(path.clone()) {
-                out.push(path);
-            }
-        }
-    }
     Ok(out)
 }
 
@@ -13113,137 +12847,13 @@ fn is_independent_extensions_root(dir: &Path) -> bool {
         .is_some_and(|name| name.eq_ignore_ascii_case("extensions"))
 }
 
-fn discover_sibling_index_entries(primary: &Path) -> Vec<PathBuf> {
-    let canonical_primary = safe_canonicalize(primary);
-    if primary
-        .file_stem()
-        .and_then(|stem| stem.to_str())
-        .is_none_or(|stem| !stem.eq_ignore_ascii_case("index"))
-    {
-        return Vec::new();
-    }
-    let Some(parent_dir) = primary.parent() else {
-        return Vec::new();
-    };
-    let Some(cluster_root) = parent_dir.parent() else {
-        return Vec::new();
-    };
-
-    // Skip sibling-index clustering when the cluster root is a known
-    // auto-discovery root (e.g., ~/.pi/agent/extensions/ or .pi/extensions/).
-    // Subdirectories there are independent extensions, not packages of a
-    // single workspace bundle. Mirrors the equivalent guard in
-    // `discover_sibling_extension_entries`.
-    if is_independent_extensions_root(cluster_root) {
-        return Vec::new();
-    }
-
-    let mut candidate_dirs = Vec::new();
-    if let Ok(entries) = fs::read_dir(cluster_root) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                candidate_dirs.push(path);
-            }
-        }
-    }
-    if candidate_dirs.len() < 2 || candidate_dirs.len() > MAX_BUNDLE_CLUSTER_DIRS {
-        return Vec::new();
-    }
-    candidate_dirs.sort();
-
-    let mut out = Vec::new();
-    let mut seen = BTreeSet::new();
-    for dir in candidate_dirs {
-        for ext in JS_EXTENSION_ENTRY_EXTS {
-            let candidate = dir.join(format!("index.{ext}"));
-            if let Some(path) = resolve_extension_entry_file(&candidate) {
-                if seen.insert(path.clone()) {
-                    out.push(path);
-                }
-                break;
-            }
-        }
-    }
-
-    if out.len() < 2 || !out.iter().any(|path| path == &canonical_primary) {
-        return Vec::new();
-    }
-    out
-}
-
-fn discover_sibling_extension_entries(primary: &Path) -> Vec<PathBuf> {
-    let canonical_primary = safe_canonicalize(primary);
-    let Some(parent_dir) = primary.parent() else {
-        return Vec::new();
-    };
-
-    // Skip sibling discovery when the parent is a known auto-discovery root
-    // (e.g., ~/.pi/agent/extensions/ or .pi/extensions/). Files in these
-    // directories are independent extensions, not siblings of a single package.
-    if is_independent_extensions_root(parent_dir) {
-        return Vec::new();
-    }
-
-    let mut out = Vec::new();
-    let mut seen = BTreeSet::new();
-    let mut sibling_files = Vec::new();
-    let mut sibling_dirs = Vec::new();
-    if let Ok(entries) = fs::read_dir(parent_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_file() && is_supported_js_extension_entry(&path) {
-                sibling_files.push(path);
-                continue;
-            }
-            if !path.is_dir() {
-                continue;
-            }
-            if let Some(index_path) = resolve_extension_entry_file(&path.join("index")) {
-                sibling_dirs.push(index_path);
-            }
-            if let Some(dir_name) = path.file_name().and_then(|name| name.to_str())
-                && let Some(named_path) = resolve_extension_entry_file(&path.join(dir_name))
-            {
-                sibling_dirs.push(named_path);
-            }
-        }
-    }
-    sibling_files.sort();
-    sibling_dirs.sort();
-
-    for path in sibling_files {
-        if !is_likely_flat_extension_entry(&path) {
-            continue;
-        }
-        let canonical = safe_canonicalize(&path);
-        if seen.insert(canonical.clone()) {
-            out.push(canonical);
-        }
-    }
-    for path in sibling_dirs {
-        if seen.insert(path.clone()) {
-            out.push(path);
-        }
-    }
-
-    if out.len() < 2 || !out.iter().any(|path| path == &canonical_primary) {
-        return Vec::new();
-    }
-
-    out
-}
-
 fn discover_related_extension_entries(primary: &Path) -> Result<Vec<PathBuf>> {
     let canonical_primary = safe_canonicalize(primary);
     let mut out = vec![canonical_primary.clone()];
     let mut seen = BTreeSet::new();
     let _ = seen.insert(canonical_primary.clone());
 
-    let mut selected_package_dir: Option<PathBuf> = None;
-    let mut selected_package_entries_len = 0usize;
     let mut selected_resolved: Vec<PathBuf> = Vec::new();
-    let mut saw_manifest_extensions = false;
     for package_json in find_package_json_ancestors(primary.parent()) {
         let Some(package_dir) = package_json.parent() else {
             continue;
@@ -13251,68 +12861,22 @@ fn discover_related_extension_entries(primary: &Path) -> Result<Vec<PathBuf>> {
         let Some(package_entries) = read_pi_extensions_from_package(&package_json)? else {
             continue;
         };
-        saw_manifest_extensions = true;
         let resolved = resolve_package_declared_entries(package_dir, &package_entries)?;
         if !resolved.contains(&canonical_primary) {
             continue;
         }
         if resolved.len() > selected_resolved.len() {
-            selected_package_dir = Some(package_dir.to_path_buf());
-            selected_package_entries_len = package_entries.len();
             selected_resolved = resolved;
         }
     }
 
-    let has_declared_package_entries = !selected_resolved.is_empty();
-    if has_declared_package_entries {
-        for path in selected_resolved {
-            if seen.insert(path.clone()) {
-                out.push(path);
-            }
-        }
-
-        let is_primary_index = canonical_primary
-            .file_stem()
-            .and_then(|stem| stem.to_str())
-            .is_some_and(|stem| stem.eq_ignore_ascii_case("index"));
-        if selected_package_entries_len == 1
-            && is_primary_index
-            && let Some(package_dir) = selected_package_dir.as_deref()
-        {
-            let bundle_entries = discover_workspace_bundle_entries(package_dir)?;
-            if bundle_entries.len() >= 2
-                && bundle_entries.iter().any(|path| path == &canonical_primary)
-            {
-                for path in bundle_entries {
-                    if seen.insert(path.clone()) {
-                        out.push(path);
-                    }
-                }
-            }
-        }
-    } else if saw_manifest_extensions {
-        return Ok(out);
-    }
-
-    if !has_declared_package_entries {
-        for path in discover_sibling_extension_entries(&canonical_primary) {
-            if seen.insert(path.clone()) {
-                out.push(path);
-            }
-        }
-    }
-    if let Some(package_dir) = selected_package_dir.as_deref() {
-        for path in discover_auxiliary_example_entries(package_dir, &canonical_primary) {
-            if seen.insert(path.clone()) {
-                out.push(path);
-            }
-        }
-    }
-    if !has_declared_package_entries {
-        for path in discover_sibling_index_entries(&canonical_primary) {
-            if seen.insert(path.clone()) {
-                out.push(path);
-            }
+    // Package resources are manifest-driven. The package manager performs
+    // `extensions/` convention discovery only when `pi.extensions` is absent,
+    // and passes every resulting entry explicitly. Do not infer sibling files,
+    // workspace packages, examples, or anything under `dependencies` here.
+    for path in selected_resolved {
+        if seen.insert(path.clone()) {
+            out.push(path);
         }
     }
 

--- a/src/extensions/tests/core.rs
+++ b/src/extensions/tests/core.rs
@@ -417,73 +417,6 @@ fn read_pi_extensions_errors_on_empty_string_entries() {
 }
 
 #[test]
-fn discover_sibling_index_entries_keeps_primary_even_when_not_sorted_first() {
-    let temp = tempdir().expect("tempdir");
-    let cluster = temp.path().join("bundle");
-    let dir_a = cluster.join("a-ext");
-    let dir_b = cluster.join("b-ext");
-    let dir_c = cluster.join("c-ext");
-    std::fs::create_dir_all(&dir_a).expect("mkdir a-ext");
-    std::fs::create_dir_all(&dir_b).expect("mkdir b-ext");
-    std::fs::create_dir_all(&dir_c).expect("mkdir c-ext");
-
-    let a_index = dir_a.join("index.ts");
-    let b_index = dir_b.join("index.ts");
-    let c_index = dir_c.join("index.ts");
-    std::fs::write(&a_index, "export default {};\n").expect("write a index");
-    std::fs::write(&b_index, "export default {};\n").expect("write b index");
-    std::fs::write(&c_index, "export default {};\n").expect("write c index");
-
-    let discovered = discover_sibling_index_entries(&b_index);
-    assert_eq!(discovered.len(), 3);
-    assert!(discovered.contains(&safe_canonicalize(&a_index)));
-    assert!(discovered.contains(&safe_canonicalize(&b_index)));
-    assert!(discovered.contains(&safe_canonicalize(&c_index)));
-}
-
-#[test]
-fn discover_sibling_index_entries_skips_auto_discovery_extensions_root() {
-    let temp = tempdir().expect("tempdir");
-    let extensions_root = temp.path().join("extensions");
-    for id in ["alpha", "beta", "gamma"] {
-        let dir = extensions_root.join(id);
-        std::fs::create_dir_all(&dir).expect("mkdir extension dir");
-        std::fs::write(dir.join("index.ts"), "export default {};\n").expect("write index");
-    }
-
-    let primary = extensions_root.join("beta").join("index.ts");
-    let discovered = discover_sibling_index_entries(&primary);
-    assert!(
-        discovered.is_empty(),
-        "independent extensions under an auto-discovery extensions root must not be clustered as a bundle: {discovered:?}"
-    );
-}
-
-#[test]
-fn discover_sibling_index_entries_ignores_huge_parent_clusters() {
-    let temp = tempdir().expect("tempdir");
-    let cluster = temp.path().join("bundle");
-    std::fs::create_dir_all(&cluster).expect("mkdir bundle");
-
-    let primary_dir = cluster.join("pkg-00");
-    std::fs::create_dir_all(&primary_dir).expect("mkdir primary dir");
-    let primary = primary_dir.join("index.ts");
-    std::fs::write(&primary, "export default {};\n").expect("write primary");
-
-    for idx in 1..=MAX_BUNDLE_CLUSTER_DIRS {
-        let dir = cluster.join(format!("pkg-{idx:02}"));
-        std::fs::create_dir_all(&dir).expect("mkdir sibling dir");
-        std::fs::write(dir.join("index.ts"), "export default {};\n").expect("write sibling index");
-    }
-
-    let discovered = discover_sibling_index_entries(&primary);
-    assert!(
-        discovered.is_empty(),
-        "large clusters should not trigger sibling index expansion"
-    );
-}
-
-#[test]
 fn discover_related_extension_entries_keeps_shared_extensions_dir_entries_independent() {
     let temp = tempdir().expect("tempdir");
     let extensions_dir = temp.path().join("extensions");
@@ -590,7 +523,7 @@ fn discover_related_extension_entries_prefers_ancestor_bundle_with_more_entries(
 }
 
 #[test]
-fn discover_related_extension_entries_includes_flat_siblings_without_manifest() {
+fn discover_related_extension_entries_does_not_infer_flat_siblings_without_manifest() {
     let temp = tempdir().expect("tempdir");
     let root = temp.path().join("flat");
     std::fs::create_dir_all(&root).expect("mkdir flat");
@@ -600,85 +533,9 @@ fn discover_related_extension_entries_includes_flat_siblings_without_manifest() 
     std::fs::write(&a, "export default function initA(_pi) {}\n").expect("write a");
     std::fs::write(&b, "export default function initB(_pi) {}\n").expect("write b");
 
-    let discovered = discover_related_extension_entries(&a).expect("discover flat sibling entries");
-    assert_eq!(discovered.len(), 2);
-    assert!(discovered.contains(&safe_canonicalize(&a)));
-    assert!(discovered.contains(&safe_canonicalize(&b)));
-}
-
-#[test]
-fn discover_related_extension_entries_includes_named_initializer_siblings() {
-    let temp = tempdir().expect("tempdir");
-    let root = temp.path().join("named-init");
-    std::fs::create_dir_all(&root).expect("mkdir named-init");
-
-    let alpha = root.join("alpha.ts");
-    let beta = root.join("beta.ts");
-    std::fs::write(&alpha, "export async function activate(_pi) {}\n").expect("write alpha");
-    std::fs::write(&beta, "export function initialize(_pi) {}\n").expect("write beta");
-
-    let discovered =
-        discover_related_extension_entries(&alpha).expect("discover named initializer");
-    assert_eq!(discovered.len(), 2);
-    assert!(discovered.contains(&safe_canonicalize(&alpha)));
-    assert!(discovered.contains(&safe_canonicalize(&beta)));
-}
-
-#[test]
-fn discover_related_extension_entries_includes_default_object_initializer_siblings() {
-    let temp = tempdir().expect("tempdir");
-    let root = temp.path().join("default-object");
-    std::fs::create_dir_all(&root).expect("mkdir default-object");
-
-    let alpha = root.join("alpha.ts");
-    let beta = root.join("beta.ts");
-    std::fs::write(&alpha, "export default { activate(_pi) {} };\n").expect("write alpha");
-    std::fs::write(&beta, "export default { initialize: async (_pi) => {} };\n")
-        .expect("write beta");
-
-    let discovered = discover_related_extension_entries(&alpha).expect("discover default object");
-    assert_eq!(discovered.len(), 2);
-    assert!(discovered.contains(&safe_canonicalize(&alpha)));
-    assert!(discovered.contains(&safe_canonicalize(&beta)));
-}
-
-#[test]
-fn discover_related_extension_entries_includes_quoted_default_object_initializer_siblings() {
-    let temp = tempdir().expect("tempdir");
-    let root = temp.path().join("quoted-default-object");
-    std::fs::create_dir_all(&root).expect("mkdir quoted-default-object");
-
-    let alpha = root.join("alpha.ts");
-    let beta = root.join("beta.ts");
-    std::fs::write(&alpha, "export default { activate(_pi) {} };\n").expect("write alpha");
-    std::fs::write(
-        &beta,
-        "export default { \"initialize\": async (_pi) => {} };\n",
-    )
-    .expect("write beta");
-
-    let discovered = discover_related_extension_entries(&alpha).expect("discover quoted object");
-    assert_eq!(discovered.len(), 2);
-    assert!(discovered.contains(&safe_canonicalize(&alpha)));
-    assert!(discovered.contains(&safe_canonicalize(&beta)));
-}
-
-#[test]
-fn discover_related_extension_entries_includes_quoted_default_object_method_siblings() {
-    let temp = tempdir().expect("tempdir");
-    let root = temp.path().join("quoted-default-method");
-    std::fs::create_dir_all(&root).expect("mkdir quoted-default-method");
-
-    let alpha = root.join("alpha.ts");
-    let beta = root.join("beta.ts");
-    std::fs::write(&alpha, "export default { activate(_pi) {} };\n").expect("write alpha");
-    std::fs::write(&beta, "export default { \"initialize\"(_pi) {} };\n").expect("write beta");
-
-    let discovered =
-        discover_related_extension_entries(&alpha).expect("discover quoted object method");
-    assert_eq!(discovered.len(), 2);
-    assert!(discovered.contains(&safe_canonicalize(&alpha)));
-    assert!(discovered.contains(&safe_canonicalize(&beta)));
+    let discovered = discover_related_extension_entries(&a).expect("resolve explicit entry");
+    assert_eq!(discovered, vec![safe_canonicalize(&a)]);
+    assert!(!discovered.contains(&safe_canonicalize(&b)));
 }
 
 #[test]
@@ -835,7 +692,7 @@ fn discover_related_extension_entries_errors_on_empty_string_manifest_entry() {
 }
 
 #[test]
-fn discover_related_extension_entries_includes_likely_example_extension_entries() {
+fn discover_related_extension_entries_does_not_infer_example_entries() {
     let temp = tempdir().expect("tempdir");
     let package_dir = temp.path().join("pkg");
     let extensions_dir = package_dir.join("extensions");
@@ -861,10 +718,9 @@ fn discover_related_extension_entries_includes_likely_example_extension_entries(
     .expect("write example entry");
     std::fs::write(&helper, "export const helper = true;\n").expect("write helper");
 
-    let discovered =
-        discover_related_extension_entries(&primary).expect("discover example entries");
-    assert!(discovered.contains(&safe_canonicalize(&primary)));
-    assert!(discovered.contains(&safe_canonicalize(&example_entry)));
+    let discovered = discover_related_extension_entries(&primary).expect("resolve manifest entry");
+    assert_eq!(discovered, vec![safe_canonicalize(&primary)]);
+    assert!(!discovered.contains(&safe_canonicalize(&example_entry)));
     assert!(
         !discovered.contains(&safe_canonicalize(&helper)),
         "non-extension helper files in examples should be ignored"
@@ -872,7 +728,7 @@ fn discover_related_extension_entries_includes_likely_example_extension_entries(
 }
 
 #[test]
-fn discover_related_extension_entries_includes_sibling_index_when_helper_files_exist() {
+fn discover_related_extension_entries_does_not_infer_sibling_indexes() {
     let temp = tempdir().expect("tempdir");
     let cluster = temp.path().join("bundle");
     let a_dir = cluster.join("a-ext");
@@ -887,42 +743,126 @@ fn discover_related_extension_entries_includes_sibling_index_when_helper_files_e
     std::fs::write(&a_helper, "export const helper = true;\n").expect("write a helper");
     std::fs::write(&b_index, "export default {};\n").expect("write b index");
 
-    let discovered =
-        discover_related_extension_entries(&a_index).expect("discover sibling indexes");
-    assert!(discovered.contains(&safe_canonicalize(&a_index)));
+    let discovered = discover_related_extension_entries(&a_index).expect("resolve explicit entry");
+    assert_eq!(discovered, vec![safe_canonicalize(&a_index)]);
     assert!(
         !discovered.contains(&safe_canonicalize(&a_helper)),
         "plain helper modules should not become synthetic extension entrypoints"
     );
-    assert!(
-        discovered.contains(&safe_canonicalize(&b_index)),
-        "sibling index entries should still be included when local helpers are present"
-    );
+    assert!(!discovered.contains(&safe_canonicalize(&b_index)));
 }
 
 #[test]
-fn discover_workspace_bundle_entries_ignores_huge_parent_clusters() {
+fn discover_related_extension_entries_does_not_load_node_modules_dependencies() {
     let temp = tempdir().expect("tempdir");
-    let cluster = temp.path().join("cluster");
-    std::fs::create_dir_all(&cluster).expect("mkdir cluster");
-    let package_dir = cluster.join("pkg-00");
+    let node_modules = temp.path().join("node_modules");
+    let package_dir = node_modules.join("pi-web-access");
     std::fs::create_dir_all(&package_dir).expect("mkdir package dir");
+    let primary = package_dir.join("index.ts");
+    std::fs::write(&primary, "export default function init(_pi) {}\n").expect("write primary");
+    std::fs::write(
+        package_dir.join("package.json"),
+        r#"{
+            "name": "pi-web-access",
+            "dependencies": {
+                "helper-extension": "1.0.0",
+                "@mozilla/readability": "1.0.0"
+            },
+            "pi": { "extensions": ["./index.ts"] }
+        }"#,
+    )
+    .expect("write package manifest");
 
-    for idx in 0..=MAX_BUNDLE_CLUSTER_DIRS {
-        let dir = cluster.join(format!("pkg-{idx:02}"));
-        std::fs::create_dir_all(&dir).expect("mkdir sibling package");
-        let entry = dir.join("index.ts");
-        std::fs::write(&entry, "export default {};\n").expect("write sibling entry");
-        std::fs::write(
-            dir.join("package.json"),
-            r#"{ "pi": { "extensions": ["./index.ts"] } }"#,
-        )
-        .expect("write sibling package");
-    }
+    let helper_dir = node_modules.join("helper-extension");
+    std::fs::create_dir_all(&helper_dir).expect("mkdir helper dependency");
+    let helper_entry = helper_dir.join("index.ts");
+    std::fs::write(&helper_entry, "export default function helper(_pi) {}\n")
+        .expect("write helper dependency");
+    std::fs::write(
+        helper_dir.join("package.json"),
+        r#"{ "name": "helper-extension", "pi": { "extensions": ["./index.ts"] } }"#,
+    )
+    .expect("write helper dependency manifest");
 
-    let discovered =
-        discover_workspace_bundle_entries(&package_dir).expect("discover workspace bundle");
-    assert!(discovered.is_empty());
+    let readability_entry = node_modules
+        .join("@mozilla")
+        .join("readability")
+        .join("Readability.js");
+    std::fs::create_dir_all(readability_entry.parent().expect("readability parent"))
+        .expect("mkdir scoped dependency");
+    std::fs::write(
+        &readability_entry,
+        "export default function Readability(_document) {}\n",
+    )
+    .expect("write scoped dependency");
+
+    let discovered = discover_related_extension_entries(&primary).expect("resolve package entry");
+    assert_eq!(discovered, vec![safe_canonicalize(&primary)]);
+    assert!(!discovered.contains(&safe_canonicalize(&helper_entry)));
+    assert!(!discovered.contains(&safe_canonicalize(&readability_entry)));
+}
+
+#[test]
+fn discover_related_extension_entries_does_not_remap_missing_dependency_entries() {
+    let temp = tempdir().expect("tempdir");
+    let package_dir = temp.path().join("pi-web-access");
+    std::fs::create_dir_all(&package_dir).expect("mkdir package dir");
+    let primary = package_dir.join("index.ts");
+    std::fs::write(&primary, "export default function init(_pi) {}\n").expect("write primary");
+    std::fs::write(
+        package_dir.join("package.json"),
+        r#"{
+            "name": "pi-web-access",
+            "pi": {
+                "extensions": [
+                    "./index.ts",
+                    "./node_modules/helper-extension/index.ts"
+                ]
+            }
+        }"#,
+    )
+    .expect("write package manifest");
+
+    let helper_dir = temp.path().join("helper-extension");
+    std::fs::create_dir_all(&helper_dir).expect("mkdir sibling helper");
+    let helper_entry = helper_dir.join("index.ts");
+    std::fs::write(&helper_entry, "export default function helper(_pi) {}\n")
+        .expect("write sibling helper");
+    std::fs::write(
+        helper_dir.join("package.json"),
+        r#"{ "name": "helper-extension", "pi": { "extensions": ["./index.ts"] } }"#,
+    )
+    .expect("write sibling helper manifest");
+
+    let discovered = discover_related_extension_entries(&primary).expect("resolve package entry");
+    assert_eq!(discovered, vec![safe_canonicalize(&primary)]);
+    assert!(!discovered.contains(&safe_canonicalize(&helper_entry)));
+}
+
+#[test]
+fn discover_related_extension_entries_preserves_scoped_primary_packages() {
+    let temp = tempdir().expect("tempdir");
+    let node_modules = temp.path().join("node_modules");
+    let package_dir = node_modules.join("@foo").join("bar");
+    let extensions_dir = package_dir.join("extensions");
+    std::fs::create_dir_all(&extensions_dir).expect("mkdir scoped package");
+    let primary = package_dir.join("index.ts");
+    let extra = extensions_dir.join("extra.ts");
+    std::fs::write(&primary, "export default function init(_pi) {}\n").expect("write primary");
+    std::fs::write(&extra, "export default function extra(_pi) {}\n").expect("write extra");
+    std::fs::write(
+        package_dir.join("package.json"),
+        r#"{
+            "name": "@foo/bar",
+            "pi": { "extensions": ["./index.ts", "./extensions/extra.ts"] }
+        }"#,
+    )
+    .expect("write package manifest");
+
+    let discovered = discover_related_extension_entries(&primary).expect("resolve scoped package");
+    assert_eq!(discovered.len(), 2);
+    assert!(discovered.contains(&safe_canonicalize(&primary)));
+    assert!(discovered.contains(&safe_canonicalize(&extra)));
 }
 
 #[allow(clippy::too_many_lines)]

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -5210,6 +5210,86 @@ mod tests {
     }
 
     #[test]
+    fn test_package_pi_manifest_without_extensions_skips_convention_directory() {
+        run_async(async {
+            let temp_dir = tempfile::tempdir().expect("tempdir");
+            let package_root = temp_dir.path().join("pkg");
+            let entry_path = package_root.join("extensions").join("index.ts");
+            fs::create_dir_all(entry_path.parent().expect("entry parent")).expect("create dir");
+            fs::write(&entry_path, "export default {}").expect("write index.ts");
+            fs::write(
+                package_root.join("package.json"),
+                serde_json::to_string_pretty(&json!({
+                    "name": "pkg",
+                    "version": "1.0.0",
+                    "pi": {
+                        "skills": []
+                    }
+                }))
+                .expect("serialize manifest"),
+            )
+            .expect("write manifest");
+
+            let manager = PackageManager::new(temp_dir.path().to_path_buf());
+            let sources = vec![package_root.to_string_lossy().to_string()];
+            let resolved = manager
+                .resolve_extension_sources(
+                    &sources,
+                    ResolveExtensionSourcesOptions {
+                        local: false,
+                        temporary: true,
+                    },
+                )
+                .await
+                .expect("resolve extension sources");
+
+            assert!(
+                resolved.extensions.is_empty(),
+                "a package with a pi manifest must only load explicitly declared resource fields"
+            );
+        });
+    }
+
+    #[test]
+    fn test_package_without_pi_manifest_uses_convention_directory() {
+        run_async(async {
+            let temp_dir = tempfile::tempdir().expect("tempdir");
+            let package_root = temp_dir.path().join("pkg");
+            let entry_path = package_root.join("extensions").join("index.ts");
+            fs::create_dir_all(entry_path.parent().expect("entry parent")).expect("create dir");
+            fs::write(&entry_path, "export default {}").expect("write index.ts");
+            fs::write(
+                package_root.join("package.json"),
+                serde_json::to_string_pretty(&json!({
+                    "name": "pkg",
+                    "version": "1.0.0"
+                }))
+                .expect("serialize manifest"),
+            )
+            .expect("write manifest");
+
+            let manager = PackageManager::new(temp_dir.path().to_path_buf());
+            let sources = vec![package_root.to_string_lossy().to_string()];
+            let resolved = manager
+                .resolve_extension_sources(
+                    &sources,
+                    ResolveExtensionSourcesOptions {
+                        local: false,
+                        temporary: true,
+                    },
+                )
+                .await
+                .expect("resolve extension sources");
+
+            assert_eq!(resolved.extensions.len(), 1);
+            let entry = &resolved.extensions[0];
+            assert_eq!(entry.path, entry_path);
+            assert!(entry.enabled);
+            assert_eq!(entry.metadata.source, sources[0]);
+        });
+    }
+
+    #[test]
     fn test_resolve_extension_sources_errors_on_malformed_package_manifest() {
         run_async(async {
             let temp_dir = tempfile::tempdir().expect("tempdir");

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1757,6 +1757,7 @@ pub async fn run(
                         );
                         inner_session.to_messages_for_current_path()
                     };
+                    let tokens_after = guard.agent.estimate_post_compaction_tokens(&messages);
                     guard.persist_session().await?;
                     guard.agent.replace_messages(messages);
 
@@ -1764,6 +1765,7 @@ pub async fn run(
                         "summary": result_data.summary,
                         "firstKeptEntryId": result_data.first_kept_entry_id,
                         "tokensBefore": result_data.tokens_before,
+                        "tokensAfter": tokens_after,
                         "details": details_value,
                     }))
                 }
@@ -4174,6 +4176,7 @@ async fn maybe_auto_compact(
                 );
                 inner_session.to_messages_for_current_path()
             };
+            let tokens_after = guard.agent.estimate_post_compaction_tokens(&messages);
             let _ = guard.persist_session().await;
             guard.agent.replace_messages(messages);
             drop(guard);
@@ -4183,6 +4186,7 @@ async fn maybe_auto_compact(
                     "summary": result.summary,
                     "firstKeptEntryId": result.first_kept_entry_id,
                     "tokensBefore": result.tokens_before,
+                    "tokensAfter": tokens_after,
                     "details": details_value,
                 })),
                 aborted: false,

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -606,6 +606,7 @@ pub struct RpcCompactionResult {
     pub summary: String,
     pub first_kept_entry_id: String,
     pub tokens_before: u64,
+    pub tokens_after: u64,
     #[serde(default)]
     pub details: Value,
 }

--- a/tests/sdk_unit.rs
+++ b/tests/sdk_unit.rs
@@ -606,12 +606,14 @@ fn rpc_compaction_result_serde() {
         "summary": "Compacted 10 messages into 2",
         "firstKeptEntryId": "entry-5",
         "tokensBefore": 12000,
+        "tokensAfter": 3200,
         "details": {"removed": 8}
     });
     let result: RpcCompactionResult = serde_json::from_value(value.clone()).expect("deserialize");
     assert_eq!(result.summary, "Compacted 10 messages into 2");
     assert_eq!(result.first_kept_entry_id, "entry-5");
     assert_eq!(result.tokens_before, 12000);
+    assert_eq!(result.tokens_after, 3200);
 
     let reencoded = serde_json::to_value(&result).expect("serialize");
     assert_eq!(reencoded, value);
@@ -623,6 +625,7 @@ fn rpc_compaction_result_serde() {
                 "tokens_before".to_string(),
                 result.tokens_before.to_string(),
             ));
+            ctx.push(("tokens_after".to_string(), result.tokens_after.to_string()));
         });
 }
 


### PR DESCRIPTION
## Summary
- What changed:
  - Aligned Rust extension discovery with Pi TypeScript package rules.
  - Removed sibling entry, workspace bundle, auxiliary example, and dependency entry inference.
  - Extension runtime now expands only entries explicitly declared by an applicable `package.json#pi.extensions`.
  - Preserved conventional `extensions/` discovery when a package has no Pi manifest.
  - Preserved scoped npm package resolution such as `node_modules/@foo/bar`.
  - Added regression tests for manifest handling, scoped packages, and prohibited inferred entries.
- Why:
  - Prevent unrelated workspace packages, dependencies, examples, and sibling files from being executed as extensions.
  - Keep Rust extension loading behavior consistent with the Pi TypeScript implementation.
- Risk level (low/medium/high): medium

## Definition of Done Evidence
- [x] Unit evidence linked
- [x] E2E evidence linked
- [ ] Extension evidence linked
- [ ] Failing paths include artifact links and repro commands

### Unit Evidence
- Primary run link(s):
  - Local validation only; no CI artifact link is available.
- Notes:
  - `cargo test discover_related_extension_entries --lib`: 16 tests passed.
  - Package manifest convention tests passed.
  - Manifest extension pattern tests passed.
  - Automatic extension collection tests passed.
  - Extension entry resolution tests passed.
  - `cargo check --lib` passed.
  - Targeted `rustfmt --check` passed.
  - `git diff --check` passed.
  - `cargo test --all-targets` is currently blocked by an unrelated existing compilation failure in `tests/capability_prompt.rs`: `PiApp::new` expects 19 arguments, while the test supplies 18.

### E2E Evidence
- Primary run link(s):
  - Not available.
- Notes:
  - Full E2E validation has not been run.
  - The standard validation path is currently blocked by the unrelated `cargo test --all-targets` compilation failure.
  - `./scripts/e2e/run_all.sh --profile ci` remains to be run after the compilation issue is resolved.

### Extension Evidence
- Primary run link(s):
  - Local validation only; no CI artifact link is available.
- Notes:
  - Validated against the `pi-web-access` extension using a local path supplied through `PI_WEB_ACCESS_DIR`.
  - The extension no longer treats ordinary package dependencies as plugin entries.
  - Remaining compatibility warnings concern partial `node:crypto` and `node:fs/promises` support and are unrelated to extension entry discovery.
  - Machine-specific paths are intentionally omitted.

## Reproduction Commands
```bash
cargo test discover_related_extension_entries --lib
cargo test test_package_pi_manifest_without_extensions_skips_convention_directory --lib
cargo test test_package_without_pi_manifest_uses_convention_directory --lib
cargo test test_manifest_extensions_resolve_with_patterns --lib
cargo check --lib

cargo test --all-targets
cargo test --all-targets --features ext-conformance
./scripts/e2e/run_all.sh --profile ci

cargo run --quiet --bin pi -- doctor "$PI_WEB_ACCESS_DIR" --only extensions
```

## Migration Guidance (Existing Feature Branches)
- If this branch was created before the DoD gate rollout, replace the PR body with this template before requesting merge.
- Packages must declare extension entry points through `package.json#pi.extensions`.
- Packages without a Pi manifest may continue using the conventional `extensions/` directory.
- Do not rely on sibling packages, dependencies, examples, or workspace files being inferred as extension entries.
- Explicit entries such as `node_modules/dep/extensions` remain supported when declared in `pi.extensions`.
- Scoped package names such as `@foo/bar` continue to resolve normally.
- For historical failing runs, include direct artifact links plus the exact rerun command used to validate the fix.
