### PR TITLE
feat(session): support JSONL-only SDK builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "pi"
 path = "src/main.rs"
+required-features = ["tui"]
 
 # RETIRABLE binary (pending RULE 1 approval)
 # Legacy capture functionality - 91KB, last modified 2026-03-12
@@ -150,7 +151,7 @@ clap = { version = "4.5.60", features = ["derive", "env", "string"] }
 clap_complete = "4.5.66"
 
 # Async runtime
-asupersync = { version = "=0.3.2", default-features = false, features = ["tls-native-roots", "test-internals"] }
+asupersync = { version = "=0.3.2", default-features = false, features = ["tls-native-roots"] }
 futures = "0.3"
 async-trait = "0.1"
 
@@ -190,8 +191,8 @@ fs4 = "0.13"
 glob = "0.3"
 ignore = "0.4"
 crossbeam-queue = "0.3"
-sqlmodel-sqlite = { version = "0.2.2" }
-sqlmodel-core = { version = "0.2.2" }
+sqlmodel-sqlite = { version = "0.2.2", optional = true }
+sqlmodel-core = { version = "0.2.2", optional = true }
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }
@@ -304,20 +305,32 @@ rquickjs = { version = "0.11", features = ["futures", "loader", "bindgen"] }
 rquickjs = { version = "0.11", features = ["futures", "loader", "bindgen"] }
 
 [features]
-default = ["sqlite-sessions"]
+default = ["sqlite-sessions", "session-index", "tui"]
 full = [
     "image-resize",
     "jemalloc",
     "clipboard",
     "wasm-host",
     "sqlite-sessions",
+    "session-index",
     "syntax-highlighting",
+    "tui",
     "rich_rust/full",
 ]
 image-resize = ["image"]
 clipboard = ["dep:arboard"]
 wasm-host = ["dep:wasmtime"]
-sqlite-sessions = []
+# SQLite conversation persistence. Keep its complete SQLModel dependency set
+# here so embedders can select JSONL without inheriting any SQLite packages.
+sqlite-sessions = ["dep:sqlmodel-core", "dep:sqlmodel-sqlite"]
+# Derived SQLite metadata index used by Pi's session picker and recent-session
+# lookup. This is independent from the conversation storage backend.
+session-index = ["dep:sqlmodel-core", "dep:sqlmodel-sqlite"]
+# The interactive CLI owns the picker and therefore requires session indexing.
+# SDK/library consumers can omit all three default features for JSONL-only use.
+# Standalone Pi retains its legacy detached context constructors. Embedded
+# runtimes use the ambient context installed by asupersync::Runtime::block_on.
+tui = ["session-index", "asupersync/test-internals"]
 syntax-highlighting = ["rich_rust/syntax"]
 ext-conformance = []
 fuzzing = []

--- a/src/agent_cx.rs
+++ b/src/agent_cx.rs
@@ -40,29 +40,42 @@ impl AgentCx {
     /// point that needs to create a fresh request context.
     #[must_use]
     pub fn for_current_or_request() -> Self {
-        Self {
-            cx: Cx::current().unwrap_or_else(Cx::for_request),
-        }
+        #[cfg(any(test, feature = "tui"))]
+        let cx = Cx::current().unwrap_or_else(Cx::for_request);
+        #[cfg(not(any(test, feature = "tui")))]
+        let cx = Cx::current()
+            .expect("embedded Pi operations require an ambient asupersync runtime context");
+        Self { cx }
     }
 
     /// Create a request-scoped context (infinite budget).
     #[must_use]
     pub fn for_request() -> Self {
-        Self {
-            cx: Cx::for_request(),
-        }
+        #[cfg(any(test, feature = "tui"))]
+        let cx = Cx::for_request();
+        #[cfg(not(any(test, feature = "tui")))]
+        let cx = Cx::current()
+            .expect("embedded Pi operations require an ambient asupersync runtime context");
+        Self { cx }
     }
 
     /// Create a request-scoped context with an explicit budget.
     #[must_use]
     pub fn for_request_with_budget(budget: Budget) -> Self {
-        Self {
-            cx: Cx::for_request_with_budget(budget),
-        }
+        #[cfg(any(test, feature = "tui"))]
+        let cx = Cx::for_request_with_budget(budget);
+        #[cfg(not(any(test, feature = "tui")))]
+        let cx = {
+            let _ = budget;
+            Cx::current()
+                .expect("embedded Pi operations require an ambient asupersync runtime context")
+        };
+        Self { cx }
     }
 
     /// Create a test-only context (infinite budget).
     #[must_use]
+    #[cfg(any(test, feature = "tui"))]
     pub fn for_testing() -> Self {
         Self {
             cx: Cx::for_testing(),
@@ -71,6 +84,7 @@ impl AgentCx {
 
     /// Create a test-only context with lab I/O capability.
     #[must_use]
+    #[cfg(any(test, feature = "tui"))]
     pub fn for_testing_with_io() -> Self {
         Self {
             cx: Cx::for_testing_with_io(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,7 @@ pub enum Error {
     Json(#[from] Box<serde_json::Error>),
 
     /// SQLite errors
+    #[cfg(any(feature = "session-index", feature = "sqlite-sessions"))]
     #[error("SQLite error: {0}")]
     Sqlite(#[from] Box<sqlmodel_core::Error>),
 
@@ -216,7 +217,9 @@ impl Error {
     pub const fn hostcall_error_code(&self) -> &'static str {
         match self {
             Self::Validation(_) => "invalid_request",
-            Self::Io(_) | Self::Session(_) | Self::SessionNotFound { .. } | Self::Sqlite(_) => "io",
+            Self::Io(_) | Self::Session(_) | Self::SessionNotFound { .. } => "io",
+            #[cfg(any(feature = "session-index", feature = "sqlite-sessions"))]
+            Self::Sqlite(_) => "io",
             Self::Auth(_) => "denied",
             Self::Aborted => "timeout",
             Self::Json(_)
@@ -241,6 +244,7 @@ impl Error {
             Self::Extension(_) => "extension",
             Self::Io(_) => "io",
             Self::Json(_) => "json",
+            #[cfg(any(feature = "session-index", feature = "sqlite-sessions"))]
             Self::Sqlite(_) => "sqlite",
             Self::Aborted => "runtime",
             Self::Api(_) => "api",
@@ -302,6 +306,7 @@ impl Error {
                 ],
                 vec![("details", err.to_string())],
             ),
+            #[cfg(any(feature = "session-index", feature = "sqlite-sessions"))]
             Self::Sqlite(err) => sqlite_hints(err),
             Self::Aborted => build_hints(
                 "Operation aborted.",
@@ -859,6 +864,7 @@ fn io_hints(err: &std::io::Error) -> ErrorHints {
     }
 }
 
+#[cfg(any(feature = "session-index", feature = "sqlite-sessions"))]
 fn sqlite_hints(err: &sqlmodel_core::Error) -> ErrorHints {
     let details = err.to_string();
     let lower = details.to_lowercase();
@@ -909,6 +915,7 @@ impl From<serde_json::Error> for Error {
     }
 }
 
+#[cfg(any(feature = "session-index", feature = "sqlite-sessions"))]
 impl From<sqlmodel_core::Error> for Error {
     fn from(value: sqlmodel_core::Error) -> Self {
         Self::Sqlite(Box::new(value))

--- a/src/error_hints.rs
+++ b/src/error_hints.rs
@@ -41,6 +41,7 @@ pub fn hints_for_error(error: &Error) -> ErrorHint {
         Error::Extension(msg) => extension_hints(msg),
         Error::Io(err) => io_hints(err),
         Error::Json(err) => json_hints(err),
+        #[cfg(any(feature = "session-index", feature = "sqlite-sessions"))]
         Error::Sqlite(err) => sqlite_hints(err),
         Error::Aborted => aborted_hints(),
         Error::Api(msg) => api_hints(msg),
@@ -422,6 +423,7 @@ fn json_hints(err: &serde_json::Error) -> ErrorHint {
     }
 }
 
+#[cfg(any(feature = "session-index", feature = "sqlite-sessions"))]
 fn sqlite_hints(err: &sqlmodel_core::Error) -> ErrorHint {
     let message = err.to_string();
     if message.contains("locked") {

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -4,6 +4,7 @@
 //! validation utilities plus a minimal WASM host scaffold.
 
 use crate::agent::AgentEvent;
+use crate::agent_cx::AgentCx;
 use crate::config::Config;
 use crate::connectors::Connector;
 use crate::connectors::http::HttpConnector;
@@ -16182,7 +16183,7 @@ fn cx_with_deadline(timeout_ms: u64) -> Cx {
         deadline: Some(wall_now() + Duration::from_millis(timeout_ms)),
         ..Budget::INFINITE
     };
-    Cx::for_request_with_budget(budget)
+    AgentCx::for_request_with_budget(budget).cx().clone()
 }
 
 /// Event names for the extension lifecycle.
@@ -18907,7 +18908,7 @@ impl JsExtensionRuntimeHandle {
                 .build()
                 .expect("extension runtime build");
             runtime.block_on(async move {
-                let cx = Cx::for_request();
+                let cx = AgentCx::for_request().cx().clone();
                 let runtime_config = config.clone();
                 let warm_pool = crate::extensions_js::WarmIsolatePool::new(runtime_config.clone());
                 let cold_init_started = Instant::now();
@@ -19356,7 +19357,7 @@ impl JsExtensionRuntimeHandle {
             });
         });
 
-        let cx = Cx::for_request();
+        let cx = AgentCx::for_request().cx().clone();
         init_rx
             .recv(&cx)
             .await
@@ -19374,7 +19375,7 @@ impl JsExtensionRuntimeHandle {
     /// to exit its event loop.  Returns `true` if the runtime exited
     /// within the budget.
     pub async fn shutdown(&self, budget: Duration) -> bool {
-        let cx = Cx::for_request();
+        let cx = AgentCx::for_request().cx().clone();
         let budget_ms = u64::try_from(budget.as_millis()).unwrap_or(u64::MAX);
 
         // Send shutdown command (ignore error if channel already closed).
@@ -19907,7 +19908,7 @@ impl JsExtensionRuntimeHandle {
                     return;
                 };
                 runtime.block_on(async move {
-                    let cx = Cx::for_request();
+                    let cx = AgentCx::for_request().cx().clone();
                     let _ = sender
                         .send(
                             &cx,
@@ -26900,9 +26901,9 @@ impl ExtensionManager {
         let budget = self.budget();
         if budget.deadline.is_some() || budget.poll_quota < u32::MAX || budget.cost_quota.is_some()
         {
-            Cx::for_request_with_budget(budget)
+            AgentCx::for_request_with_budget(budget).cx().clone()
         } else {
-            Cx::for_request()
+            AgentCx::for_request().cx().clone()
         }
     }
 
@@ -30337,7 +30338,7 @@ impl ExtensionManager {
         &self,
         mut request: ExtensionUiRequest,
     ) -> Result<Option<ExtensionUiResponse>> {
-        let cx = Cx::for_request();
+        let cx = AgentCx::for_request().cx().clone();
         if request.id.trim().is_empty() {
             request.id = Uuid::new_v4().to_string();
         }
@@ -30406,7 +30407,7 @@ impl ExtensionManager {
     }
 
     pub fn respond_ui(&self, response: ExtensionUiResponse) -> bool {
-        let cx = Cx::for_request();
+        let cx = AgentCx::for_request().cx().clone();
         let tx = {
             let mut guard = self
                 .inner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub mod conformance_shapes;
 pub mod connectors;
 #[doc(hidden)]
 pub mod crypto_shim;
+#[cfg(feature = "session-index")]
 #[doc(hidden)]
 pub mod doctor;
 #[doc(hidden)]
@@ -141,6 +142,7 @@ pub mod hostcall_trace_jit;
 pub mod http;
 #[doc(hidden)]
 pub mod http_shim;
+#[cfg(feature = "tui")]
 #[doc(hidden)]
 pub mod interactive;
 #[doc(hidden)]
@@ -186,10 +188,12 @@ pub mod semantic_workspace_graph;
 #[doc(hidden)]
 pub mod session;
 #[doc(hidden)]
+#[cfg(feature = "session-index")]
 pub mod session_index;
 #[doc(hidden)]
 pub mod session_metrics;
 #[doc(hidden)]
+#[cfg(all(feature = "session-index", feature = "tui"))]
 pub mod session_picker;
 #[cfg(feature = "sqlite-sessions")]
 #[doc(hidden)]

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -142,7 +142,7 @@ where
 {
     let mut future = Box::pin(future);
     std::future::poll_fn(move |poll_cx| {
-        let _guard = asupersync::Cx::set_current(Some(current_cx.clone()));
+        let _guard = current_cx.clone().set_current_restricted();
         future.as_mut().poll(poll_cx)
     })
 }
@@ -4767,7 +4767,7 @@ async fn run_bash_rpc(
     let _stderr_handle = std::thread::spawn(move || pump_bash_rpc_stream(stderr, tx, "stderr"));
 
     let tick = Duration::from_millis(10);
-    let cx = asupersync::Cx::current().unwrap_or_else(asupersync::Cx::for_request);
+    let cx = AgentCx::for_current_or_request();
 
     // Bounded buffer state (same logic as BashTool)
     let mut chunks: VecDeque<Vec<u8>> = VecDeque::new();

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -13,6 +13,16 @@
 //! let _tools: Vec<ToolDefinition> = Vec::new();
 //! ```
 //!
+//! # JSONL-only embedding
+//!
+//! Compile Pi with `default-features = false` to exclude SQLite conversation
+//! storage and session indexing. Call [`create_agent_session_with_store`] with
+//! [`SessionStoreKind::Jsonl`] when persistence must be JSONL regardless of the
+//! user's global Pi configuration. Existing JSONL files can be resumed through
+//! [`SessionOptions::session_path`].
+//!
+//! The default feature composition remains intended for the standalone Pi CLI
+//! and includes its SQLite backend, index, and interactive session picker.
 //! Internal implementation types are intentionally not part of this surface.
 //!
 //! ```compile_fail
@@ -53,7 +63,7 @@ pub use crate::provider::{
     Context as ProviderContext, InputType, Model, ModelCost, Provider, StreamOptions,
     ThinkingBudgets as ProviderThinkingBudgets, ToolDef,
 };
-pub use crate::session::Session;
+pub use crate::session::{Session, SessionStoreKind};
 pub use crate::tools::{Tool, ToolOutput, ToolRegistry, ToolUpdate};
 
 /// Stable alias for model-exposed tool schema definitions.
@@ -1647,8 +1657,28 @@ fn build_stream_options_with_optional_key(
 ///
 /// This is the programmatic entrypoint for non-CLI consumers that want to run
 /// Pi sessions in-process.
-#[allow(clippy::too_many_lines)]
 pub async fn create_agent_session(options: SessionOptions) -> Result<AgentSessionHandle> {
+    create_agent_session_inner(options, None).await
+}
+
+/// Create an embeddable agent session with an explicit conversation store.
+///
+/// This overrides only conversation persistence for this SDK session. It does
+/// not mutate global Pi configuration, and selecting [`SessionStoreKind::Jsonl`]
+/// prevents an embedder from inheriting a user's global SQLite store setting.
+/// A JSONL path supplied through [`SessionOptions::session_path`] is opened and
+/// resumed normally.
+pub async fn create_agent_session_with_store(
+    options: SessionOptions,
+    store_kind: SessionStoreKind,
+) -> Result<AgentSessionHandle> {
+    create_agent_session_inner(options, Some(store_kind)).await
+}
+#[allow(clippy::too_many_lines)]
+async fn create_agent_session_inner(
+    options: SessionOptions,
+    store_kind_override: Option<SessionStoreKind>,
+) -> Result<AgentSessionHandle> {
     let process_cwd =
         std::env::current_dir().map_err(|e| Error::config(format!("cwd lookup failed: {e}")))?;
     let cwd = options.working_directory.as_deref().map_or_else(
@@ -1689,7 +1719,10 @@ pub async fn create_agent_session(options: SessionOptions) -> Result<AgentSessio
         }
     }
 
-    let config = Config::load()?;
+    let mut config = Config::load()?;
+    if let Some(store_kind) = store_kind_override {
+        config.session_store = Some(store_kind.as_str().to_string());
+    }
 
     let mut auth = AuthStorage::load_async(Config::auth_path()).await?;
     auth.refresh_expired_oauth_tokens().await?;
@@ -2003,6 +2036,70 @@ mod tests {
         assert_eq!(header_cwd, sdk_cwd.path().display().to_string());
         assert_eq!(path.parent(), Some(expected_dir.as_path()));
         assert_ne!(path.parent(), Some(process_dir.as_path()));
+    }
+
+    #[cfg(not(feature = "session-index"))]
+    #[test]
+    fn explicit_jsonl_store_persists_and_resumes_via_sdk() {
+        let sdk_cwd = tempdir().expect("sdk cwd");
+        let session_root = tempdir().expect("session root");
+        let base_options = SessionOptions {
+            provider: Some("openai".to_string()),
+            model: Some("gpt-4o".to_string()),
+            api_key: Some("dummy-key".to_string()),
+            working_directory: Some(sdk_cwd.path().to_path_buf()),
+            no_session: false,
+            session_dir: Some(session_root.path().to_path_buf()),
+            ..SessionOptions::default()
+        };
+
+        let handle = run_async(create_agent_session_with_store(
+            base_options.clone(),
+            SessionStoreKind::Jsonl,
+        ))
+        .expect("create explicit JSONL session");
+        let (path, session_id) = run_async(async {
+            let cx = crate::agent_cx::AgentCx::for_request();
+            let mut guard = handle
+                .session()
+                .session
+                .lock(cx.cx())
+                .await
+                .expect("lock session");
+            guard.append_message(crate::session::SessionMessage::User {
+                content: UserContent::Text("persisted through SDK".to_string()),
+                timestamp: Some(0),
+            });
+            guard.save().await.expect("save explicit JSONL session");
+            (
+                guard.path.clone().expect("saved session path"),
+                guard.header.id.clone(),
+            )
+        });
+        assert_eq!(path.extension().and_then(|ext| ext.to_str()), Some("jsonl"));
+
+        let resumed = run_async(create_agent_session_with_store(
+            SessionOptions {
+                session_path: Some(path),
+                ..base_options
+            },
+            SessionStoreKind::Jsonl,
+        ))
+        .expect("resume explicit JSONL session");
+        let (resumed_id, message_count) = run_async(async {
+            let cx = crate::agent_cx::AgentCx::for_request();
+            let guard = resumed
+                .session()
+                .session
+                .lock(cx.cx())
+                .await
+                .expect("lock resumed session");
+            (guard.header.id.clone(), guard.to_messages().len())
+        });
+
+        assert_eq!(resumed_id, session_id);
+        assert_eq!(message_count, 1);
+        assert!(!session_root.path().join("session-index.sqlite").exists());
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -13,11 +13,12 @@ use crate::model::{
     UserMessage,
 };
 use crate::provider_metadata::{canonical_provider_id, provider_ids_match};
+#[cfg(feature = "session-index")]
 use crate::session_index::{
-    SessionIndex, SessionIndexRefreshSummary, enqueue_session_index_snapshot_update,
-    is_session_file_path, session_file_stats,
+    SessionIndex, enqueue_session_index_snapshot_update, is_session_file_path, session_file_stats,
 };
 use crate::session_store_v2::{self, SessionStoreV2};
+#[cfg(feature = "session-index")]
 use crate::tui::PiConsole;
 use asupersync::channel::oneshot;
 use asupersync::sync::Mutex;
@@ -28,13 +29,15 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
-use std::io::{BufReader, IsTerminal, Read, Write};
+#[cfg(feature = "session-index")]
+use std::io::IsTerminal;
+use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::thread;
 use std::time::Instant;
-#[cfg(test)]
+#[cfg(all(test, feature = "session-index"))]
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::warn;
 
@@ -149,17 +152,22 @@ fn save_jsonl_full_rewrite_blocking(
         .persist(path)
         .map_err(|e| crate::Error::Io(Box::new(e.error)))?;
     sync_parent_dir(path).map_err(|e| crate::Error::Io(Box::new(e)))?;
-    let mut entries_for_stats = entries_to_write.clone();
-    let finalized = finalize_loaded_entries(&mut entries_for_stats);
-    let message_count = finalized.message_count;
-    let session_name = finalized.name;
-    enqueue_session_index_snapshot_update(
-        sessions_root,
-        path,
-        &header_to_write,
-        message_count,
-        session_name,
-    );
+    #[cfg(feature = "session-index")]
+    {
+        let mut entries_for_stats = entries_to_write.clone();
+        let finalized = finalize_loaded_entries(&mut entries_for_stats);
+        let message_count = finalized.message_count;
+        let session_name = finalized.name;
+        enqueue_session_index_snapshot_update(
+            sessions_root,
+            path,
+            &header_to_write,
+            message_count,
+            session_name,
+        );
+    }
+    #[cfg(not(feature = "session-index"))]
+    let _ = sessions_root;
     Ok((header_to_write, entries_to_write))
 }
 
@@ -179,7 +187,10 @@ fn append_jsonl_entries_blocking(
     file.write_all(serialized_entries)?;
     file.sync_all().map_err(|e| crate::Error::Io(Box::new(e)))?;
 
+    #[cfg(feature = "session-index")]
     enqueue_session_index_snapshot_update(sessions_root, path, header, message_count, session_name);
+    #[cfg(not(feature = "session-index"))]
+    let _ = (sessions_root, header, message_count, session_name);
     Ok(())
 }
 
@@ -553,6 +564,16 @@ pub enum SessionStoreKind {
 }
 
 impl SessionStoreKind {
+    /// Stable configuration value for this conversation store.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Jsonl => "jsonl",
+            #[cfg(feature = "sqlite-sessions")]
+            Self::Sqlite => "sqlite",
+        }
+    }
+
     fn from_config(config: &Config) -> Self {
         let Some(value) = config.session_store.as_deref() else {
             return Self::Jsonl;
@@ -1019,7 +1040,7 @@ pub struct SessionColdStartPhaseTrace {
 }
 
 /// Incremental session-index refresh summary.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SessionColdStartIndexRefreshTrace {
     pub scanned_files: usize,
     pub cache_hit_files: usize,
@@ -1281,24 +1302,39 @@ impl Session {
         }
 
         if cli.resume {
-            let picker_input_override = config
-                .session_picker_input
-                .filter(|value| *value > 0)
-                .map(|value| value.to_string());
-            let mut session = Box::pin(Self::resume_with_picker(
-                session_dir.as_deref(),
-                config,
-                picker_input_override,
-            ))
-            .await?;
-            session.set_autosave_durability_mode(durability_mode);
-            return Ok(session);
+            #[cfg(feature = "session-index")]
+            {
+                let picker_input_override = config
+                    .session_picker_input
+                    .filter(|value| *value > 0)
+                    .map(|value| value.to_string());
+                let mut session = Box::pin(Self::resume_with_picker(
+                    session_dir.as_deref(),
+                    config,
+                    picker_input_override,
+                ))
+                .await?;
+                session.set_autosave_durability_mode(durability_mode);
+                return Ok(session);
+            }
+            #[cfg(not(feature = "session-index"))]
+            return Err(Error::session(
+                "Session picker requires the `session-index` feature",
+            ));
         }
 
         if cli.r#continue {
-            let mut session = Self::continue_recent_in_dir(session_dir.as_deref(), config).await?;
-            session.set_autosave_durability_mode(durability_mode);
-            return Ok(session);
+            #[cfg(feature = "session-index")]
+            {
+                let mut session =
+                    Self::continue_recent_in_dir(session_dir.as_deref(), config).await?;
+                session.set_autosave_durability_mode(durability_mode);
+                return Ok(session);
+            }
+            #[cfg(not(feature = "session-index"))]
+            return Err(Error::session(
+                "Recent-session lookup requires the `session-index` feature",
+            ));
         }
 
         let store_kind = SessionStoreKind::from_config(config);
@@ -1311,6 +1347,7 @@ impl Session {
 
     /// Resume a session by prompting the user to select from recent sessions.
     #[allow(clippy::too_many_lines)]
+    #[cfg(feature = "session-index")]
     pub async fn resume_with_picker(
         override_dir: Option<&Path>,
         config: &Config,
@@ -1575,6 +1612,8 @@ impl Session {
         path: &Path,
         sessions_root: &Path,
     ) -> Result<SessionColdStartTraceBundle> {
+        #[cfg(not(feature = "session-index"))]
+        let _ = sessions_root;
         let total_start = Instant::now();
         let mut phases = Vec::with_capacity(4);
         let mut storage = session_cold_start_storage_trace(path);
@@ -1589,21 +1628,30 @@ impl Session {
             status: "ok".to_string(),
         });
 
-        let index_start = Instant::now();
-        let index_summary = SessionIndex::for_sessions_root(sessions_root).refresh_incremental()?;
-        phases.push(SessionColdStartPhaseTrace {
-            name: "session_index_refresh".to_string(),
-            elapsed_us: elapsed_us_since(index_start),
-            status: "ok".to_string(),
-        });
-        let index_refresh = SessionColdStartIndexRefreshTrace {
-            scanned_files: index_summary.scanned_files,
-            cache_hit_files: index_summary.reused_files,
-            reused_files: index_summary.reused_files,
-            refreshed_files: index_summary.refreshed_files,
-            pruned_rows: index_summary.pruned_rows,
-            failed_files: index_summary.failed_files,
+        #[cfg(feature = "session-index")]
+        let (index_refresh, indexed_files_scanned) = {
+            let index_start = Instant::now();
+            let index_summary =
+                SessionIndex::for_sessions_root(sessions_root).refresh_incremental()?;
+            phases.push(SessionColdStartPhaseTrace {
+                name: "session_index_refresh".to_string(),
+                elapsed_us: elapsed_us_since(index_start),
+                status: "ok".to_string(),
+            });
+            (
+                SessionColdStartIndexRefreshTrace {
+                    scanned_files: index_summary.scanned_files,
+                    cache_hit_files: index_summary.reused_files,
+                    reused_files: index_summary.reused_files,
+                    refreshed_files: index_summary.refreshed_files,
+                    pruned_rows: index_summary.pruned_rows,
+                    failed_files: index_summary.failed_files,
+                },
+                index_summary.scanned_files,
+            )
         };
+        #[cfg(not(feature = "session-index"))]
+        let (index_refresh, indexed_files_scanned) = (Default::default(), 0);
 
         let compaction_start = Instant::now();
         let compaction_scan = session.cold_start_compaction_scan_trace();
@@ -1621,8 +1669,11 @@ impl Session {
             status: "ok".to_string(),
         });
 
-        let replay_minimization =
-            session.cold_start_replay_minimization_trace(&storage, &index_summary, &diagnostics);
+        let replay_minimization = session.cold_start_replay_minimization_trace(
+            &storage,
+            indexed_files_scanned,
+            &diagnostics,
+        );
 
         let bundle = SessionColdStartTraceBundle {
             schema: SESSION_COLD_START_TRACE_SCHEMA.to_string(),
@@ -1756,7 +1807,7 @@ impl Session {
     fn cold_start_replay_minimization_trace(
         &self,
         storage: &SessionColdStartStorageTrace,
-        index_summary: &SessionIndexRefreshSummary,
+        indexed_files_scanned: usize,
         diagnostics: &SessionOpenDiagnostics,
     ) -> SessionReplayMinimizationTrace {
         let path_entries = self.cold_start_current_path_entries();
@@ -1775,7 +1826,7 @@ impl Session {
         let (entry_count, branch_count) = self.cold_start_total_entries_and_branch_count();
         let skipped_sibling_entries = entry_count.saturating_sub(selected_depth);
         let deterministic_steps = selected_depth
-            .saturating_add(index_summary.scanned_files)
+            .saturating_add(indexed_files_scanned)
             .saturating_add(diagnostics.skipped_entries.len())
             .saturating_add(diagnostics.orphaned_parent_links.len());
         let opened_backend = storage.opened_backend.as_str();
@@ -1819,7 +1870,7 @@ impl Session {
             branch_count,
             entry_count,
             selected_depth,
-            scanned_files: index_summary.scanned_files,
+            scanned_files: indexed_files_scanned,
             replayed_entries,
             skipped_sibling_entries,
             deterministic_steps,
@@ -2012,14 +2063,14 @@ impl Session {
     async fn open_v2_with_diagnostics(path: &Path) -> Result<(Self, SessionOpenDiagnostics)> {
         let path_buf = path.to_path_buf();
         let (tx, mut rx) = oneshot::channel();
+        let cx = AgentCx::for_request();
+        let worker_cx = cx.cx().clone();
 
         let handle = thread::spawn(move || {
             let res = crate::session::open_from_v2_store_blocking(path_buf);
-            let cx = AgentCx::for_request();
-            let _ = tx.send(cx.cx(), res);
+            let _ = tx.send(&worker_cx, res);
         });
 
-        let cx = AgentCx::for_request();
         let recv_result = rx.recv(cx.cx()).await;
         finish_worker_result(handle, recv_result, "V2 open task cancelled")
     }
@@ -2027,14 +2078,14 @@ impl Session {
     async fn open_jsonl_with_diagnostics(path: &Path) -> Result<(Self, SessionOpenDiagnostics)> {
         let path_buf = path.to_path_buf();
         let (tx, mut rx) = oneshot::channel();
+        let cx = AgentCx::for_request();
+        let worker_cx = cx.cx().clone();
 
         let handle = thread::spawn(move || {
             let res = open_jsonl_blocking(path_buf);
-            let cx = AgentCx::for_request();
-            let _ = tx.send(cx.cx(), res);
+            let _ = tx.send(&worker_cx, res);
         });
 
-        let cx = AgentCx::for_request();
         let recv_result = rx.recv(cx.cx()).await;
         finish_worker_result(handle, recv_result, "Open task cancelled")
     }
@@ -2075,6 +2126,7 @@ impl Session {
     }
 
     /// Continue the most recent session.
+    #[cfg(feature = "session-index")]
     pub async fn continue_recent_in_dir(
         override_dir: Option<&Path>,
         config: &Config,
@@ -2592,14 +2644,17 @@ impl Session {
                     // No new entries → no-op, nothing to write.
                 }
 
-                let sessions_root = session_dir_clone.unwrap_or_else(Config::sessions_dir);
-                enqueue_session_index_snapshot_update(
-                    &sessions_root,
-                    &path_clone,
-                    &self.header,
-                    message_count,
-                    session_name,
-                );
+                #[cfg(feature = "session-index")]
+                {
+                    let sessions_root = session_dir_clone.unwrap_or_else(Config::sessions_dir);
+                    enqueue_session_index_snapshot_update(
+                        &sessions_root,
+                        &path_clone,
+                        &self.header,
+                        message_count,
+                        session_name,
+                    );
+                }
             }
         }
         Ok(())
@@ -3646,6 +3701,7 @@ pub struct SiblingBranch {
 }
 
 #[derive(Debug, Clone)]
+#[cfg(feature = "session-index")]
 struct SessionPickEntry {
     path: PathBuf,
     id: String,
@@ -3657,6 +3713,7 @@ struct SessionPickEntry {
     size_bytes: u64,
 }
 
+#[cfg(feature = "session-index")]
 impl SessionPickEntry {
     fn from_meta(meta: crate::session_index::SessionMeta) -> Self {
         Self {
@@ -3685,6 +3742,7 @@ impl SessionPickEntry {
     }
 }
 
+#[cfg(feature = "session-index")]
 fn indexed_session_path_is_missing(path: &Path) -> bool {
     match path.try_exists() {
         Ok(exists) => !exists,
@@ -3699,6 +3757,7 @@ fn indexed_session_path_is_missing(path: &Path) -> bool {
     }
 }
 
+#[cfg(feature = "session-index")]
 fn split_indexed_session_entries(
     metas: Vec<crate::session_index::SessionMeta>,
 ) -> (Vec<SessionPickEntry>, Vec<PathBuf>) {
@@ -3718,6 +3777,7 @@ fn split_indexed_session_entries(
     (entries, missing_paths)
 }
 
+#[cfg(feature = "session-index")]
 fn prune_session_index_path(index: &SessionIndex, path: &Path, reason: &'static str) {
     if let Err(err) = index.delete_session_path(path) {
         tracing::warn!(
@@ -3729,18 +3789,21 @@ fn prune_session_index_path(index: &SessionIndex, path: &Path, reason: &'static 
     }
 }
 
+#[cfg(feature = "session-index")]
 fn can_reuse_known_entry(known_entry: &SessionPickEntry, disk_ms: i64, disk_size: u64) -> bool {
     (known_entry.last_modified_ms, known_entry.size_bytes)
         .cmp(&(disk_ms, disk_size))
         .is_eq()
 }
 
+#[cfg(feature = "session-index")]
 struct ScanSessionsResult {
     entries: Vec<SessionPickEntry>,
     refreshed_entries: Vec<SessionPickEntry>,
     failed_paths: Vec<PathBuf>,
 }
 
+#[cfg(feature = "session-index")]
 fn refresh_session_index_entries(
     index: &SessionIndex,
     entries: &[SessionPickEntry],
@@ -3758,6 +3821,7 @@ fn refresh_session_index_entries(
     }
 }
 
+#[cfg(feature = "session-index")]
 fn merge_scanned_session_entries(
     by_path: &mut HashMap<PathBuf, SessionPickEntry>,
     entries: Vec<SessionPickEntry>,
@@ -3770,6 +3834,7 @@ fn merge_scanned_session_entries(
     }
 }
 
+#[cfg(feature = "session-index")]
 async fn scan_sessions_on_disk(
     project_session_dir: &Path,
     known: Vec<SessionPickEntry>,
@@ -3831,6 +3896,7 @@ async fn scan_sessions_on_disk(
     finish_worker_result(handle, recv_result, "Scan task cancelled")
 }
 
+#[cfg(feature = "session-index")]
 fn load_session_meta(path: &Path) -> Result<SessionPickEntry> {
     match path.extension().and_then(|ext| ext.to_str()) {
         Some("jsonl") => load_session_meta_jsonl(path),
@@ -3844,6 +3910,7 @@ fn load_session_meta(path: &Path) -> Result<SessionPickEntry> {
 }
 
 #[derive(Deserialize)]
+#[cfg(feature = "session-index")]
 struct PartialEntry {
     #[serde(default)]
     r#type: String,
@@ -3851,6 +3918,7 @@ struct PartialEntry {
     name: Option<String>,
 }
 
+#[cfg(feature = "session-index")]
 fn load_session_meta_jsonl(path: &Path) -> Result<SessionPickEntry> {
     let file = std::fs::File::open(path)
         .map_err(|e| Error::session(format!("Failed to read session: {e}")))?;
@@ -3902,6 +3970,7 @@ fn load_session_meta_jsonl(path: &Path) -> Result<SessionPickEntry> {
 }
 
 #[cfg(feature = "sqlite-sessions")]
+#[cfg(feature = "session-index")]
 fn load_session_meta_sqlite(path: &Path) -> Result<SessionPickEntry> {
     let meta = futures::executor::block_on(async {
         crate::session_sqlite::load_session_meta(path).await
@@ -7031,6 +7100,7 @@ mod tests {
     }
 
     #[allow(clippy::too_many_lines)]
+    #[cfg(feature = "session-index")]
     #[test]
     fn cold_start_replay_minimization_bounds_branch_heavy_v2_resume() {
         const FORKS: usize = 700;
@@ -7314,6 +7384,32 @@ mod tests {
         assert!(types.contains(&"session_info".to_string()));
     }
 
+    #[cfg(not(feature = "session-index"))]
+    #[test]
+    fn jsonl_persistence_resumes_without_session_index() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut session = Session::create_with_dir(Some(temp.path().to_path_buf()));
+        session.append_message(make_test_message("before resume"));
+
+        run_async(async { session.save().await }).expect("save JSONL session");
+        let path = session.path.clone().expect("saved JSONL path");
+        assert_eq!(path.extension().and_then(|ext| ext.to_str()), Some("jsonl"));
+        assert!(!temp.path().join("session-index.sqlite").exists());
+
+        let path_string = path.to_string_lossy().into_owned();
+        let mut resumed =
+            run_async(async { Session::open(&path_string).await }).expect("resume JSONL session");
+        assert_eq!(resumed.to_messages().len(), 1);
+        resumed.append_message(make_test_message("after resume"));
+        run_async(async { resumed.save().await }).expect("save resumed JSONL session");
+
+        let reopened =
+            run_async(async { Session::open(&path_string).await }).expect("reopen JSONL session");
+        assert_eq!(reopened.to_messages().len(), 2);
+        assert!(!temp.path().join("session-index.sqlite").exists());
+    }
+
+    #[cfg(feature = "session-index")]
     #[test]
     fn cold_start_trace_bundle_is_bounded_redacted_and_cache_aware() {
         let temp = tempdir_under_tmpdir("pi-session-cold-start-");
@@ -9089,6 +9185,7 @@ mod tests {
         assert_ne!(path.parent(), Some(process_dir.as_path()));
     }
 
+    #[cfg(feature = "session-index")]
     #[test]
     fn test_can_reuse_known_entry_requires_matching_mtime_and_size() {
         let known_entry = SessionPickEntry {
@@ -9145,6 +9242,7 @@ mod tests {
         assert_eq!(next_line, "y\n");
     }
 
+    #[cfg(feature = "session-index")]
     #[test]
     fn test_scan_sessions_on_disk_ignores_stale_known_entry_when_size_mismatch() {
         let temp = tempfile::tempdir().unwrap();
@@ -9187,6 +9285,7 @@ mod tests {
         assert_eq!(scanned.entries[0].size_bytes, disk_size);
     }
 
+    #[cfg(feature = "session-index")]
     #[test]
     fn test_merge_scanned_session_entries_replaces_cached_entry_when_size_changes() {
         let path = PathBuf::from("session.jsonl");
@@ -9224,6 +9323,7 @@ mod tests {
         assert_eq!(merged.size_bytes, 8192);
     }
 
+    #[cfg(feature = "session-index")]
     #[test]
     fn test_merge_scanned_session_entries_replaces_cached_entry_even_if_disk_mtime_regresses() {
         let path = PathBuf::from("session.jsonl");
@@ -9262,6 +9362,7 @@ mod tests {
         assert_eq!(merged.size_bytes, 2048);
     }
 
+    #[cfg(feature = "session-index")]
     #[test]
     fn test_scan_sessions_on_disk_reports_failed_paths_for_corrupt_changed_session() {
         let temp = tempfile::tempdir().unwrap();
@@ -9304,6 +9405,7 @@ mod tests {
         assert_eq!(scanned.failed_paths, vec![path]);
     }
 
+    #[cfg(feature = "session-index")]
     #[test]
     fn test_continue_recent_in_dir_prunes_corrupt_stale_index_entry() {
         let _lock = current_dir_lock();
@@ -9353,6 +9455,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "session-index")]
     #[test]
     fn test_continue_recent_in_dir_prunes_missing_stale_index_entry() {
         let _lock = current_dir_lock();
@@ -9402,6 +9505,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "session-index")]
     #[test]
     fn test_continue_recent_in_dir_prunes_index_when_project_dir_is_missing() {
         let _lock = current_dir_lock();
@@ -9445,6 +9549,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "session-index")]
     #[cfg(unix)]
     #[test]
     fn split_indexed_session_entries_keeps_permission_denied_path_out_of_missing_bucket() {
@@ -9493,6 +9598,7 @@ mod tests {
         assert_eq!(entries[0].path, session_path);
     }
 
+    #[cfg(feature = "session-index")]
     #[cfg(unix)]
     #[test]
     fn test_continue_recent_in_dir_prunes_unreadable_cached_entry_on_open_failure() {
@@ -9543,6 +9649,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "session-index")]
     #[test]
     fn test_continue_recent_in_dir_refreshes_index_after_changed_disk_session() {
         let _lock = current_dir_lock();
@@ -9585,6 +9692,7 @@ mod tests {
         assert_eq!(indexed[0].name.as_deref(), Some("Refreshed"));
     }
 
+    #[cfg(feature = "session-index")]
     #[test]
     fn test_resume_with_picker_refreshes_index_after_changed_disk_session() {
         let _lock = current_dir_lock();
@@ -9632,6 +9740,7 @@ mod tests {
         assert_eq!(indexed[0].name.as_deref(), Some("Refreshed"));
     }
 
+    #[cfg(feature = "session-index")]
     #[test]
     fn test_load_session_meta_jsonl_errors_on_invalid_utf8_entry_line() {
         use std::io::Write;
@@ -9670,7 +9779,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "sqlite-sessions")]
+    #[cfg(all(feature = "sqlite-sessions", feature = "session-index"))]
     #[test]
     fn test_scan_sessions_on_disk_reloads_sqlite_when_wal_stats_change() {
         let temp = tempfile::tempdir().unwrap();
@@ -9716,7 +9825,7 @@ mod tests {
         assert_eq!(scanned.entries[0].last_modified_ms, updated_ms);
     }
 
-    #[cfg(feature = "sqlite-sessions")]
+    #[cfg(all(feature = "sqlite-sessions", feature = "session-index"))]
     #[test]
     fn test_load_session_meta_sqlite_uses_wal_aware_stats() {
         let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- make SQLModel dependencies optional behind `sqlite-sessions` and a new `session-index` feature
- keep standalone Pi defaults behavior-compatible, including SQLite conversations, picker/index, and TUI
- support `default-features = false` as the minimal JSONL-only SDK composition
- add `create_agent_session_with_store(..., SessionStoreKind::Jsonl)` so embedders can override global Pi store configuration per session
- gate index enqueue, refresh, picker, pruning, scans, and related modules/callers

## Provenance

This patch is intentionally based directly on `895269a3f5ec8ff3d8482e9339ccecaa57b618ec`, the exact Pi commit in the Margins Cargo.lock. That commit is an ancestor of current `main`; current upstream has subsequently migrated toward fsqlite, so maintainers may prefer to port the API/feature seam rather than merge this old-snapshot patch directly.

## Validation

- `cargo check --all-targets` default: pass
- `cargo check --lib` in default and `--no-default-features`: pass
- focused default session-index persistence test: pass
- focused no-index JSONL persistence/resume test: pass
- focused SDK explicit JSONL persistence/resume test: pass
- minimal normal/build `cargo tree`: zero matches for SQLModel, libsqlite3-sys, rusqlite, SQLite session/index, or test-internals
- focused rustfmt and `git diff --check`: pass

## Known repository baseline

- the full library suite is blocked by existing mock-HTTP auth tests that hang under parallel execution; unrelated serial cases pass
- full `cargo fmt --check` reports pre-existing drift in unchanged `src/http/client.rs`
- current nightly Clippy reports broad pre-existing lint upgrades; the changed-line finding was fixed
- host lacks the repository wrapper CLIs `ubs` and `br`
