### PR TITLE
Fix prebuilt-binary glibc breakage on older distributions (build on old glibc + installer guard)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -489,10 +489,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          # Pinned to ubuntu-22.04 (glibc 2.35), NOT ubuntu-latest (=24.04,
+          # glibc 2.39). Release binaries must link against the oldest glibc
+          # we intend to support; building on ubuntu-latest silently raises
+          # the runtime requirement and breaks every older distribution with
+          # "version `GLIBC_2.xx' not found" at launch.
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             asset: pi-linux-amd64
+          # No ubuntu-22.04 hosted ARM runner exists, so pin the glibc
+          # baseline via a container instead. rust:bullseye is multi-arch
+          # (works on the ARM runner), ships glibc 2.31, and already contains
+          # git/curl/gcc so checkout and rustup work out of the box.
           - os: ubuntu-24.04-arm
+            container: rust:bullseye
             target: aarch64-unknown-linux-gnu
             asset: pi-linux-arm64
           - os: macos-15-intel
@@ -505,6 +515,10 @@ jobs:
             target: x86_64-pc-windows-msvc
             asset: pi-windows-amd64
     runs-on: ${{ matrix.os }}
+    # Optional per-matrix container (used to pin the glibc baseline for
+    # architectures without an old-glibc hosted runner). When the key is
+    # absent this evaluates to null, i.e. no container.
+    container: ${{ matrix.container }}
     timeout-minutes: 60
     env:
       CI: "true"
@@ -623,8 +637,22 @@ jobs:
             exit 1
           fi
 
+      - name: Install system deps (xcb + build tools) [linux container]
+        if: runner.os == 'Linux' && matrix.container != ''
+        run: |
+          set -euxo pipefail
+          # Running as root inside the container: no sudo. rust:bullseye already
+          # provides git, curl, ca-certificates, and a C toolchain.
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            pkg-config \
+            libxcb1-dev \
+            libxcb-render0-dev \
+            libxcb-shape0-dev \
+            libxcb-xfixes0-dev
+
       - name: Install system deps (xcb + build tools) [linux]
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.container == ''
         run: |
           set -euxo pipefail
           sudo apt-get update

--- a/install.sh
+++ b/install.sh
@@ -254,6 +254,29 @@ capture_version_line() {
   printf '%s\n' "$out"
 }
 
+# Runs a freshly downloaded release artifact once (--version) BEFORE it is
+# installed. Release binaries link against the builder's glibc; hosts running
+# older distributions (e.g. Ubuntu 22.04 glibc 2.35 receiving a binary built on
+# Ubuntu 24.04 glibc 2.39) fail at launch with:
+#   /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by pi)
+# Prints nothing. Returns 0 iff the binary executed successfully.
+artifact_runs_on_host() {
+  local bin_path="$1"
+  local err_file="$TMP/smoke.err"
+  chmod +x "$bin_path" 2>/dev/null || true
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 15 "$bin_path" --version >/dev/null 2>"$err_file"
+  else
+    "$bin_path" --version >/dev/null 2>"$err_file"
+  fi
+}
+
+# True iff the smoke-test stderr shows the specific dynamic-loader
+# "version `GLIBC_x.yy' not found" failure shape.
+artifact_missing_glibc() {
+  grep -Eq "version \`GLIBC_[0-9.]+' not found" "$TMP/smoke.err" 2>/dev/null
+}
+
 is_managed_alias() {
   local path="$1"
   [ -f "$path" ] || return 1
@@ -3495,6 +3518,25 @@ main() {
     local download_rc=0
     if run_with_spinner "Downloading release binary" download_release_binary > "$TMP/source_bin_path"; then
       source_bin=$(cat "$TMP/source_bin_path")
+      # Pre-install smoke test: never install a binary this host cannot load.
+      # Scoped to the exact glibc-mismatch failure shape so unrelated nonzero
+      # exits (or non-standard artifacts) keep the previous behavior.
+      if ! artifact_runs_on_host "$source_bin" && artifact_missing_glibc; then
+        warn "Downloaded release binary requires a newer glibc than this system provides"
+        warn "Host: $(ldd --version 2>/dev/null | head -1)"
+        if [ "$OFFLINE" -eq 1 ] || [ -n "$ARTIFACT_URL" ]; then
+          err "Cannot auto-fallback; re-run with --from-source, or upgrade the base system"
+          exit 1
+        fi
+        warn "Falling back to building from source against the local toolchain"
+        FROM_SOURCE=1
+        INSTALL_SOURCE="source (glibc fallback)"
+        CHECKSUM_STATUS="not applicable (source fallback)"
+        SIGSTORE_STATUS="not applicable (source fallback)"
+        check_dependencies
+        run_with_spinner "Building pi from source" build_from_source > "$TMP/source_bin_path"
+        source_bin=$(cat "$TMP/source_bin_path")
+      fi
     else
       download_rc=$?
       if [ "$download_rc" -eq 2 ] || [ "$download_rc" -eq 3 ] || [ "$download_rc" -eq 4 ]; then

--- a/src/extensions_js.rs
+++ b/src/extensions_js.rs
@@ -8764,7 +8764,141 @@ export async function refreshOpenAICodexToken(_refreshToken) {
   failClosedUnsupported("refreshOpenAICodexToken");
 }
 
-export default { StringEnum, calculateCost, getEnvApiKey, getOAuthApiKey, createAssistantMessageEventStream, stream, streamSimple, streamSimpleAnthropic, streamSimpleOpenAIResponses, streamSimpleOpenAICompletions, complete, completeSimple, getProviders, getModel, getApiProvider, getApiProviders, registerApiProvider, unregisterApiProviders, getModels, loginOpenAICodex, refreshOpenAICodexToken };
+const __piOverflowPatterns = [
+  /prompt is too long/i,
+  /request_too_large/i,
+  /input is too long for requested model/i,
+  /exceeds the context window/i,
+  /exceeds (?:the )?(?:model'?s )?maximum context length(?: of [\d,]+ tokens?|\s*\([\d,]+\))/i,
+  /input token count.*exceeds the maximum/i,
+  /maximum prompt length is \d+/i,
+  /reduce the length of the messages/i,
+  /maximum context length is \d+ tokens/i,
+  /exceeds (?:the )?maximum allowed input length of [\d,]+ tokens?/i,
+  /input \(\d+ tokens\) is longer than the model'?s context length \(\d+ tokens\)/i,
+  /exceeds the limit of \d+/i,
+  /exceeds the available context size/i,
+  /greater than the context length/i,
+  /context window exceeds limit/i,
+  /exceeded model token limit/i,
+  /too large for model with \d+ maximum context length/i,
+  /prompt has [\d,]+ tokens?, but the configured context size is [\d,]+ tokens?/i,
+  /model_context_window_exceeded/i,
+  /prompt too long; exceeded (?:max )?context length/i,
+  /range of input length should be/i,
+  /context[_ ]length[_ ]exceeded/i,
+  /too many tokens/i,
+  /token limit exceeded/i,
+  /^4(?:00|13)\s*(?:status code)?\s*\(no body\)/i,
+];
+
+const __piNonOverflowPatterns = [
+  /^(Throttling error|Service unavailable):/i,
+  /rate limit/i,
+  /too many requests/i,
+];
+
+export function getOverflowPatterns() {
+  return [...__piOverflowPatterns];
+}
+
+export function isContextOverflow(message, contextWindow) {
+  if (message && message.stopReason === "error" && message.errorMessage) {
+    const isNonOverflow = __piNonOverflowPatterns.some((p) => p.test(message.errorMessage));
+    if (!isNonOverflow && __piOverflowPatterns.some((p) => p.test(message.errorMessage))) {
+      return true;
+    }
+  }
+  const usage = message && typeof message.usage === "object" ? message.usage : {};
+  const inputTokens = Number(usage.input ?? 0) + Number(usage.cacheRead ?? 0);
+  if (contextWindow && message && message.stopReason === "stop") {
+    if (inputTokens > contextWindow) {
+      return true;
+    }
+  }
+  if (contextWindow && message && message.stopReason === "length" && Number(usage.output ?? 0) === 0) {
+    if (inputTokens >= contextWindow * 0.99) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function isRecoverableLength(message, desiredMaxOutput) {
+  return Boolean(
+    message
+      && message.stopReason === "length"
+      && Number(desiredMaxOutput ?? 0) > 0
+      && message.usage
+      && Number(message.usage.output ?? 0) < Number(desiredMaxOutput),
+  );
+}
+
+const __piRetryableProviderErrorPattern = new RegExp([
+  "overloaded",
+  "rate.?limit",
+  "too many requests",
+  "429",
+  "500",
+  "502",
+  "503",
+  "504",
+  "524",
+  "service.?unavailable",
+  "server.?error",
+  "internal.?error",
+  "provider.?returned.?error",
+  "exceeded request buffer limit while retrying upstream",
+  "network.?error",
+  "connection.?error",
+  "connection.?refused",
+  "connection.?lost",
+  "other side closed",
+  "fetch failed",
+  "getaddrinfo",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "upstream.?connect",
+  "reset before headers",
+  "socket hang up",
+  "socket connection was closed",
+  "timed? out",
+  "timeout",
+  "terminated",
+  "websocket.?closed",
+  "websocket.?error",
+  "ended without",
+  "stream ended before message_stop",
+  "stream ended before a terminal response event",
+  "http2 request did not get a response",
+  "retry delay",
+  "you can retry your request",
+  "try your request again",
+  "please retry your request",
+  "ResourceExhausted",
+].join("|"), "i");
+
+const __piNonRetryableProviderLimitErrorPattern = new RegExp([
+  "GoUsageLimitError",
+  "FreeUsageLimitError",
+  "Monthly usage limit reached",
+  "available balance",
+  "insufficient_quota",
+  "out of budget",
+  "quota exceeded",
+  "billing",
+].join("|"), "i");
+
+export function isRetryableAssistantError(message) {
+  if (!message || message.stopReason !== "error" || !message.errorMessage)
+    return false;
+  const errorMessage = String(message.errorMessage);
+  if (__piNonRetryableProviderLimitErrorPattern.test(errorMessage))
+    return false;
+  return __piRetryableProviderErrorPattern.test(errorMessage);
+}
+
+export default { StringEnum, calculateCost, getEnvApiKey, getOAuthApiKey, createAssistantMessageEventStream, stream, streamSimple, streamSimpleAnthropic, streamSimpleOpenAIResponses, streamSimpleOpenAICompletions, complete, completeSimple, getProviders, getModel, getApiProvider, getApiProviders, registerApiProvider, unregisterApiProviders, getModels, loginOpenAICodex, refreshOpenAICodexToken, isContextOverflow, isRecoverableLength, getOverflowPatterns, isRetryableAssistantError };
 "#)
         .trim()
         .to_string(),


### PR DESCRIPTION
## Problem

On Ubuntu 22.04 (glibc 2.35) and any other older-glibc distribution, the documented one-liner install succeeds but the binary immediately fails:

```
pi-rust: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by pi-rust)
```

**Root cause:** the `x86_64-unknown-linux-gnu` release asset is built on `ubuntu-latest`, which currently resolves to Ubuntu 24.04 (glibc 2.39). The binary therefore links against a newer glibc than many supported hosts provide, and `install.sh` happily installs it — checksum ✅, signature ✅, launch 💥.

Reproduced on Ubuntu 22.04.5 LTS / WSL2 with v0.3.0.

## Fix

### 1. Build release binaries against an old glibc baseline (`.github/workflows/release.yml`)

- **x86_64:** pin the build runner to `ubuntu-22.04` (glibc 2.35) instead of `ubuntu-latest`. Binaries linked against 2.35 run everywhere ≥ 2.35 — including all newer distros.
- **arm64:** GitHub offers no ubuntu-22.04 hosted ARM runner, so keep `ubuntu-24.04-arm` but build inside a `rust:bullseye` container (multi-arch, **glibc 2.31**, ships git/curl/gcc so checkout and rustup work out of the box). Added a per-matrix `container` key; when absent it evaluates to null (no container). The apt-get step is split into a root-user container variant (no sudo there) and the existing sudo variant, gated by `matrix.container`.

### 2. Installer guard (`install.sh`) — defense in depth

After download + checksum verification, smoke-test the artifact with `--version` before installing:

- If it fails with the exact dynamic-loader shape \`version `GLIBC_x.yy' not found\`, warn with the host's glibc line and **fall back to building from source** against the local toolchain (reusing the existing source-fallback machinery).
- Offline / custom-artifact modes get an explicit error telling the user to use `--from-source` instead of installing a broken binary.
- Deliberately scoped to that failure signature so unrelated nonzero exits or non-standard artifacts keep the previous behavior.

End-to-end check against a fixture artifact emitting the real loader error on a glibc 2.35 host:

```
⚠ Downloaded release binary requires a newer glibc than this system provides
⚠ Host: ldd (Ubuntu GLIBC 2.35-0ubuntu3.14) 2.35
✗ Cannot auto-fallback; re-run with --from-source, or upgrade the base system
(nothing installed)
```

## Testing

- `bash -n install.sh` passes; workflow YAML validates.
- `tests/installer_regression.sh`: **47 passed / 1 failed** — the single failure (`test_release_publish_no_verify_is_secret_scoped`) also fails on unmodified `main` (pre-existing, unrelated).
- Manually verified the smoke test triggers only on the glibc signature and that the offline path aborts cleanly.

## Notes for reviewers

- Alternative/additional option not taken here: publishing `x86_64-unknown-linux-musl` static binaries would sidestep glibc entirely, but changes the dependency/clipboard/jemalloc story; happy to explore in a follow-up if preferred.
- If you'd rather keep `ubuntu-latest` for x86_64 and rely solely on the installer fallback, that also works — but users without a Rust toolchain still get no working binary, so I'd argue both layers are warranted.