### PR TITLE
feat(http): support system/custom CA certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Repository: <https://github.com/Dicklesworthstone/pi_agent_rust>
 
 ### Added
 
+- **System/custom CA certificate support** (gh
+  [#186](https://github.com/Dicklesworthstone/pi_agent_rust/issues/186)):
+  `PI_HTTP_USE_SYSTEM_CERTS=1` switches the HTTP client from the bundled
+  webpki roots to the OS trust store. Setting `SSL_CERT_FILE`, `SSL_CERT_DIR`,
+  `REQUESTS_CA_BUNDLE`, or `CURL_CA_BUNDLE` does the same and also merges that
+  bundle in — needed behind a TLS-terminating corporate proxy. Webpki roots
+  stay the default (see #101: the OS trust store is expensive to load on
+  macOS).
+
 - **Host-mediated native-Responses compaction bridge** (gh
   [#167](https://github.com/Dicklesworthstone/pi_agent_rust/issues/167)):
   `ctx.compact(preparation, { strategy: "openai-responses-native", request })`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "prost",
  "rmp-serde",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "semver",
@@ -1245,6 +1246,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5183,6 +5194,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6516,6 +6533,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6588,6 +6617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6609,6 +6647,29 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2 0.11.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,7 @@ clap = { version = "4.5.60", features = ["derive", "env", "string"] }
 clap_complete = "4.5.66"
 
 # Async runtime
-asupersync = { version = "0.4.4", default-features = false, features = ["tls-webpki-roots", "test-internals"] }
+asupersync = { version = "0.4.4", default-features = false, features = ["tls-webpki-roots", "tls-native-roots", "test-internals"] }
 futures = "0.3"
 async-trait = "0.1"
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -231,18 +231,49 @@ pub struct Client {
 static TLS_CONNECTOR: std::sync::OnceLock<std::result::Result<TlsConnector, String>> =
     std::sync::OnceLock::new();
 
-/// Build (or fetch the cached) TLS connector backed by the bundled webpki
-/// root certificates.
+/// Explicit opt-in for the OS/system trust store instead of the bundled
+/// webpki roots. See [`use_system_certs`].
+pub const USE_SYSTEM_CERTS_ENV: &str = "PI_HTTP_USE_SYSTEM_CERTS";
+
+/// True when the operator wants the OS trust store (plus any custom CA it
+/// points at) instead of the bundled webpki roots - needed behind a
+/// TLS-terminating corporate proxy. Triggered explicitly by
+/// `PI_HTTP_USE_SYSTEM_CERTS`, or implicitly by setting any of the
+/// OpenSSL-style custom-CA vars (`SSL_CERT_FILE`, `SSL_CERT_DIR`,
+/// `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`) - setting one of those *is* the
+/// opt-in signal for asupersync's `enable_env_cert_loading()`. See
+/// pi_agent_rust#186.
+fn use_system_certs() -> bool {
+    std::env::var_os(USE_SYSTEM_CERTS_ENV).is_some()
+        || std::env::var_os("SSL_CERT_FILE").is_some()
+        || std::env::var_os("SSL_CERT_DIR").is_some()
+        || std::env::var_os("REQUESTS_CA_BUNDLE").is_some()
+        || std::env::var_os("CURL_CA_BUNDLE").is_some()
+}
+
+/// Build (or fetch the cached) TLS connector.
 ///
-/// Using webpki roots avoids hitting the OS trust store, which on macOS calls
-/// into Security.framework (`SecTrustSettingsCopyTrustSettings`) and can spend
+/// Defaults to the bundled webpki root certificates: using webpki roots
+/// avoids hitting the OS trust store, which on macOS calls into
+/// Security.framework (`SecTrustSettingsCopyTrustSettings`) and can spend
 /// many seconds at high CPU parsing the system cert trust plist on startup.
 /// See pi_agent_rust#101.
+///
+/// [`use_system_certs`] switches to the OS trust store plus any custom CA
+/// bundle it's pointed at instead - see pi_agent_rust#186.
 fn shared_tls_connector() -> std::result::Result<TlsConnector, String> {
     TLS_CONNECTOR
         .get_or_init(|| {
-            TlsConnectorBuilder::new()
-                .with_webpki_roots()
+            let builder = TlsConnectorBuilder::new();
+            let builder = if use_system_certs() {
+                builder
+                    .enable_env_cert_loading()
+                    .with_native_roots()
+                    .map_err(|e| e.to_string())?
+            } else {
+                builder.with_webpki_roots()
+            };
+            builder
                 .alpn_protocols(vec![b"http/1.1".to_vec()])
                 .build()
                 .map_err(|e| e.to_string())


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- `asupersync` (the TLS/HTTP dependency) already implements native-roots + OpenSSL-style env-var CA loading (`SSL_CERT_FILE`/`SSL_CERT_DIR`/`REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE`); `pi_agent_rust` just never turned the feature on or wired it up.
- Enables `asupersync`'s `tls-native-roots` feature and adds a `PI_HTTP_USE_SYSTEM_CERTS` opt-in (also triggered implicitly by any of the CA env vars above) that switches the shared TLS connector from bundled webpki roots to the OS trust store + custom CA.
- Default behavior (webpki roots) is unchanged - see #101 on why that's the default.

## Test plan

- [x] `cargo check --lib` - clean
- [x] `cargo clippy --lib -- -D warnings` - clean on the touched file (pre-existing unrelated clippy errors elsewhere are toolchain-drift noise from running a newer stable clippy than the repo's pinned nightly, not from this change)

## Related

- Closes #186
