### PR TITLE
feat(providers): send session-scoped prompt_cache_key on OpenAI-shaped requests

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1248,6 +1248,24 @@ pub fn cache_retention_from_env(value: Option<&str>) -> CacheRetention {
     }
 }
 
+/// Resolve the cache-affinity key serialized as `prompt_cache_key` on
+/// OpenAI-shaped requests.
+///
+/// Defaults to the session id, so every request of a session targets the same
+/// provider cache shard (OpenAI and Azure route by prefix hash combined with
+/// this key; without it, streamed requests can get no prompt-cache affinity at
+/// all — observed as a 0% cache hit rate on Azure OpenAI behind a LiteLLM
+/// proxy while non-streamed requests cached fine). `PI_PROMPT_CACHE_KEY`
+/// overrides: `off`/`none` disables the field, any other non-empty value is
+/// sent verbatim (a shared key across sessions).
+pub fn prompt_cache_key_from_env(value: Option<&str>, session_id: Option<&str>) -> Option<String> {
+    match value.map(str::trim) {
+        Some(v) if v.eq_ignore_ascii_case("off") || v.eq_ignore_ascii_case("none") => None,
+        Some(v) if !v.is_empty() => Some(v.to_string()),
+        _ => session_id.map(str::to_string),
+    }
+}
+
 pub fn build_stream_options(
     config: &Config,
     api_key: Option<String>,
@@ -1263,6 +1281,10 @@ pub fn build_stream_options(
         // and users pay full input-token price on every turn.
         cache_retention: cache_retention_from_env(
             std::env::var("PI_CACHE_RETENTION").ok().as_deref(),
+        ),
+        prompt_cache_key: prompt_cache_key_from_env(
+            std::env::var("PI_PROMPT_CACHE_KEY").ok().as_deref(),
+            Some(session.header.id.as_str()),
         ),
         // Seed the per-request output cap from the model registry's `maxTokens`
         // so the value users configure in `models.json` actually takes effect.
@@ -2268,6 +2290,33 @@ mod tests {
                 .expect("active branch thinking level should restore");
 
         assert_eq!(selection.thinking_level, model::ThinkingLevel::High);
+    }
+
+    #[test]
+    fn prompt_cache_key_from_env_resolution() {
+        // Default: the session id, so a session's requests share a cache shard.
+        assert_eq!(
+            prompt_cache_key_from_env(None, Some("sess-1")),
+            Some("sess-1".to_string())
+        );
+        // Explicit value wins verbatim (shared key across sessions).
+        assert_eq!(
+            prompt_cache_key_from_env(Some("shared"), Some("sess-1")),
+            Some("shared".to_string())
+        );
+        // "off"/"none" disable the field entirely.
+        assert_eq!(prompt_cache_key_from_env(Some("off"), Some("sess-1")), None);
+        assert_eq!(
+            prompt_cache_key_from_env(Some("NONE"), Some("sess-1")),
+            None
+        );
+        // Blank env falls back to the session id.
+        assert_eq!(
+            prompt_cache_key_from_env(Some("  "), Some("sess-1")),
+            Some("sess-1".to_string())
+        );
+        // No env, no session id: nothing to send.
+        assert_eq!(prompt_cache_key_from_env(None, None), None);
     }
 
     #[test]

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -214,6 +214,13 @@ pub struct StreamOptions {
     pub api_key: Option<String>,
     pub cache_retention: CacheRetention,
     pub session_id: Option<String>,
+    /// Cache-affinity key serialized as `prompt_cache_key` on OpenAI-shaped
+    /// requests (chat completions, Azure, Responses). OpenAI and Azure route a
+    /// request to a cache shard by prefix hash combined with this key; some
+    /// stacks (observed on Azure OpenAI behind a proxy) give streamed requests
+    /// no prompt-cache affinity at all without it. Session-scoped by default;
+    /// `PI_PROMPT_CACHE_KEY` overrides (see `app::prompt_cache_key_from_env`).
+    pub prompt_cache_key: Option<String>,
     pub headers: HashMap<String, String>,
     pub thinking_level: Option<ThinkingLevel>,
     pub thinking_budgets: Option<ThinkingBudgets>,

--- a/src/providers/azure.rs
+++ b/src/providers/azure.rs
@@ -187,6 +187,7 @@ impl AzureOpenAIProvider {
             stream_options: Some(AzureStreamOptions {
                 include_usage: true,
             }),
+            prompt_cache_key: options.prompt_cache_key.clone(),
         }
     }
 
@@ -692,6 +693,12 @@ pub struct AzureRequest {
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     stream_options: Option<AzureStreamOptions>,
+    /// Cache-affinity key (`prompt_cache_key`). Azure routes a request to a
+    /// prompt-cache shard by prefix hash combined with this key; without it,
+    /// streamed requests can get no cache affinity at all. See
+    /// `StreamOptions::prompt_cache_key`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt_cache_key: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1101,6 +1108,34 @@ mod tests {
         assert_eq!(request_json["messages"][2]["role"], json!("assistant"));
         assert_eq!(request_json["tools"][0]["type"], json!("function"));
         assert_eq!(request_json["tools"][0]["function"]["name"], json!("echo"));
+    }
+
+    #[test]
+    fn test_azure_build_request_serializes_prompt_cache_key() {
+        let provider = AzureOpenAIProvider::new("contoso", "gpt-4o");
+        let context = Context {
+            system_prompt: None,
+            messages: vec![Message::User(UserMessage {
+                content: UserContent::Text("Hello".to_string()),
+                timestamp: 0,
+            })]
+            .into(),
+            tools: Vec::new().into(),
+        };
+
+        let options = StreamOptions {
+            prompt_cache_key: Some("session-abc".to_string()),
+            ..Default::default()
+        };
+        let request_json = serde_json::to_value(provider.build_request(&context, &options))
+            .expect("serialize request");
+        assert_eq!(request_json["prompt_cache_key"], "session-abc");
+
+        // Absent when unset, so backends that reject unknown params never see it.
+        let request_json =
+            serde_json::to_value(provider.build_request(&context, &StreamOptions::default()))
+                .expect("serialize request");
+        assert!(request_json.get("prompt_cache_key").is_none());
     }
 
     #[test]

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -362,6 +362,7 @@ impl OpenAIProvider {
             stream_options,
             thinking,
             reasoning_effort,
+            prompt_cache_key: options.prompt_cache_key.clone(),
         }
     }
 
@@ -1335,6 +1336,12 @@ pub struct OpenAIRequest<'a> {
     /// compat config) is sent verbatim.
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning_effort: Option<&'a str>,
+    /// Cache-affinity key (OpenAI `prompt_cache_key`). Providers route a
+    /// request to a prompt-cache shard by prefix hash combined with this key;
+    /// without it, streamed requests can get no cache affinity at all. See
+    /// `StreamOptions::prompt_cache_key`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt_cache_key: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1801,6 +1808,34 @@ mod tests {
         let provider = OpenAIProvider::new("gpt-4o");
         assert_eq!(provider.name(), "openai");
         assert_eq!(provider.api(), "openai-completions");
+    }
+
+    #[test]
+    fn test_build_request_serializes_prompt_cache_key() {
+        let provider = OpenAIProvider::new("gpt-4o");
+        let context = Context {
+            system_prompt: None,
+            messages: vec![Message::User(crate::model::UserMessage {
+                content: UserContent::Text("Ping".to_string()),
+                timestamp: 0,
+            })]
+            .into(),
+            tools: Vec::new().into(),
+        };
+
+        let options = StreamOptions {
+            prompt_cache_key: Some("session-abc".to_string()),
+            ..Default::default()
+        };
+        let value = serde_json::to_value(provider.build_request(&context, &options))
+            .expect("serialize request");
+        assert_eq!(value["prompt_cache_key"], "session-abc");
+
+        // Absent when unset, so backends that reject unknown params never see it.
+        let value =
+            serde_json::to_value(provider.build_request(&context, &StreamOptions::default()))
+                .expect("serialize request");
+        assert!(value.get("prompt_cache_key").is_none());
     }
 
     #[test]

--- a/src/providers/openai_responses.rs
+++ b/src/providers/openai_responses.rs
@@ -205,6 +205,7 @@ impl OpenAIResponsesProvider {
             text,
             include,
             reasoning,
+            prompt_cache_key: options.prompt_cache_key.clone(),
         }
     }
 }
@@ -1662,6 +1663,11 @@ pub struct OpenAIResponsesRequest {
     include: Option<Vec<&'static str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning: Option<OpenAIResponsesReasoning>,
+    /// Cache-affinity key (OpenAI `prompt_cache_key`). Parity with the TS
+    /// `openai-responses` provider, which already sends it. See
+    /// `StreamOptions::prompt_cache_key`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt_cache_key: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -2286,6 +2292,33 @@ mod tests {
                 "rewrite must be rejected: {label}"
             );
         }
+    }
+
+    #[test]
+    fn test_build_request_serializes_prompt_cache_key() {
+        let provider = OpenAIResponsesProvider::new("gpt-4o");
+        let context = Context::owned(
+            None,
+            vec![Message::User(crate::model::UserMessage {
+                content: UserContent::Text("Ping".to_string()),
+                timestamp: 0,
+            })],
+            Vec::new(),
+        );
+
+        let options = StreamOptions {
+            prompt_cache_key: Some("session-abc".to_string()),
+            ..Default::default()
+        };
+        let value = serde_json::to_value(provider.build_request(&context, &options))
+            .expect("serialize request");
+        assert_eq!(value["prompt_cache_key"], "session-abc");
+
+        // Absent when unset, so backends that reject unknown params never see it.
+        let value =
+            serde_json::to_value(provider.build_request(&context, &StreamOptions::default()))
+                .expect("serialize request");
+        assert!(value.get("prompt_cache_key").is_none());
     }
 
     #[test]

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -1796,6 +1796,10 @@ fn build_stream_options_with_optional_key(
         cache_retention: app::cache_retention_from_env(
             std::env::var("PI_CACHE_RETENTION").ok().as_deref(),
         ),
+        prompt_cache_key: app::prompt_cache_key_from_env(
+            std::env::var("PI_PROMPT_CACHE_KEY").ok().as_deref(),
+            Some(session.header.id.as_str()),
+        ),
         // Seed the per-request output cap from the model registry's `maxTokens`
         // so embedders inherit the configured limit by default; they can still
         // override it via `set_max_tokens`.


### PR DESCRIPTION
Chat-completions, Azure, and Responses requests never carry `prompt_cache_key`. I traced a ~100% prompt-cache miss on an agent workload back to that.

Setup: an `openai-completions` provider entry pointed at a LiteLLM proxy (1.92.0 and 1.98.0, same result) in front of Azure OpenAI. Over 30 days the proxy's analytics put this workload at a 0.3% cache hit rate on 15.6M uncached input tokens. Other workloads on the same proxy, whose clients do send `prompt_cache_key`, sit between 83% and 95%.

Probing the stack directly (~2.8k-token prompts, reading `usage.prompt_tokens_details` off non-streamed calls, 3s between calls):

- Identical non-streamed calls: second call reports `cached_tokens: 2907` of 2910. Implicit caching works.
- Growing prefix at agent pace (+~500 tokens per turn): rolling hits, only the new tokens written each turn. Cost per call drops from $0.01265 cold to $0.00391 warm.
- Three identical streamed calls, then the same prompt non-streamed: `cached=0`, full cache write. Reproduced twice. TTFB across the three streamed calls is flat (1.61s / 1.75s / 1.58s), so they weren't hitting under some other key either. Streamed requests neither read nor write the cache on this stack.
- Two streamed calls with `prompt_cache_key` set, then the same prompt non-streamed: `cached_tokens: 2772` of 2775. The key alone fixes it.

pi always streams, so on a stack like this every request pays the uncached rate for the entire conversation prefix, every tool iteration. OpenAI documents cache routing as a hash of the first ~256 prompt tokens combined with `prompt_cache_key`; without the key, load-balanced traffic has no shard affinity. OpenHands hit the same thing behind LiteLLM — 38.8% hit rate, $679 vs $198 against a baseline on the same 497 SWE-bench instances — and fixed it by pinning `prompt_cache_key` to the conversation id (OpenHands/software-agent-sdk#2904).

The change:

- `StreamOptions.prompt_cache_key`, resolved where `cache_retention` already is (both the CLI and SDK option builders). Default is the session id: stable within a session, distinct across sessions, which is what OpenAI recommends for conversation-shaped prefixes.
- `PI_PROMPT_CACHE_KEY` overrides it, same shape as `PI_CACHE_RETENTION`: `off`/`none` drops the field, anything else is sent verbatim as a shared key.
- Serialized on `OpenAIRequest`, `AzureRequest`, and `OpenAIResponsesRequest` with `skip_serializing_if`, so when unset the wire format is byte-identical to today and strict OpenAI-compatible backends never see an unknown param.
- Tests: env resolution, plus a serialize/omit test per provider.

The TS providers already send this (`openai-responses.ts`, `azure-openai-responses.ts` under `legacy_pi_mono_code`); the Rust port dropped it. Same bug class as #103 — the timestamped system prompt that broke the cache prefix — approached from the other end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
